### PR TITLE
Fixed broken link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Example
 
 
 You find more examples in the
-`tests.py <https://github.com/cleder/pygeoif/blob/master/pygeoif/tests.py>`_
+`test_main.py <https://github.com/cleder/pygeoif/blob/master/pygeoif/test_main.py>`_
 file which cover every aspect of pygeoif or in fastkml_.
 
 Classes


### PR DESCRIPTION
Additionally, the link at the bottom of the README in the "signed_area" section pointing to: "http://www.cgafaq.info/wiki/Polygon_Area" is broken, but I'm not sure where that should be updated to.
