### PR TITLE
Add informative __repr__ for _Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 .tox/
 *.egg/
 *.egg-info/
+.idea/
+
+*.pyc
+
+
+

--- a/pygeoif/geometry.py
+++ b/pygeoif/geometry.py
@@ -33,28 +33,42 @@ class _Feature(object):
 
     def __repr__(self):
         if self._type == 'Point':
-            return("Point({0}, {1})".format(self.x, self.y))
+            return("Point({}, {})".format(self.x, self.y))
         elif self._type == 'LineString':
-            return "<LineString Instance Coordinates " \
-                   "{}>".format(len(self.coords))
+            instance = "LineString Instance"
+            qty = len(self.coords)
+            return "<{} {} Coords>".format(instance, qty)
         elif self._type == 'LinearRing':
-            return "<LinearRing Instance Coordinate Sets " \
-                   "{}>".format(len(self.coords))
+            instance = "LinearRing Instance"
+            qty = len(self.coords)
+            return "<{} {} Coords>".format(instance, qty)
         elif self._type == 'Polygon':
-            return "<Polygon Instance {} Interiors {} Exterior" \
-                   "  >".format(len(self._interiors.coords),
-                                len(self._exterior.coords))
+            instance = "Polygon Instance"
+            inter_qty = len(self._interiors)
+            exter_qty = len(self._exterior.coords)
+            return "<{} {} Interior {} Exterior>".format(instance, inter_qty,
+                                                         exter_qty)
         elif self._type == 'MultiPoint':
-            return "<MultiPoint Instance {} Points".format(len(self.geoms))
+            instance = "MultiPoint Instance"
+            qty = len(self.geoms)
+            return "<{} {} Points>".format(instance, qty)
         elif self._type == 'MultiLineString':
-            return "<MultiLineString Instance, {} Lines, " \
-                   "bbox {} ".format(len(self._geoms), self.bounds)
+            instance = "MultiLineString Instance"
+            qty = len(self._geoms)
+            bounds = self.bounds
+            return "<{} {} Lines {} bbox>".format(instance, qty, bounds)
         elif self._type == 'MultiPolygon':
-            return "<MultiPolygon Instance, {} Polygons, " \
-                   "bbox {} ".format(len(self._geoms), self.bounds)
+            instance = "MultiPolygon Instance"
+            qty = len(self._geoms)
+            bounds = self.bounds
+            return "<{} {} Polygons {} bbox>".format(instance, qty, bounds)
         elif self._type == 'GeometryCollection':
-            return "<GeometryCollection Instance,{} geometries, " \
-                   "bbox {} ".format(len(self._geoms), self.bounds)
+            instance = "GeometryCollection Instance"
+            qty = len(self._geoms)
+            bounds = self.bounds
+            return "<{} {} Geometries {} bbox>".format(instance, qty, bounds)
+        else:
+            return object.__repr__(self)
 
     def __str__(self):
         return self.to_wkt()

--- a/pygeoif/geometry.py
+++ b/pygeoif/geometry.py
@@ -33,40 +33,41 @@ class _Feature(object):
 
     def __repr__(self):
         if self._type == 'Point':
-            return("Point({}, {})".format(self.x, self.y))
+            return("Point({0}, {1})".format(self.x, self.y))
         elif self._type == 'LineString':
             instance = "LineString Instance"
             qty = len(self.coords)
-            return "<{} {} Coords>".format(instance, qty)
+            return "<{0} {1} Coords>".format(instance, qty)
         elif self._type == 'LinearRing':
             instance = "LinearRing Instance"
             qty = len(self.coords)
-            return "<{} {} Coords>".format(instance, qty)
+            return "<{0} {1} Coords>".format(instance, qty)
         elif self._type == 'Polygon':
             instance = "Polygon Instance"
             inter_qty = len(self._interiors)
             exter_qty = len(self._exterior.coords)
-            return "<{} {} Interior {} Exterior>".format(instance, inter_qty,
-                                                         exter_qty)
+            return "<{0} {1} Interior {2} Exterior>".format(
+                instance, inter_qty, exter_qty)
         elif self._type == 'MultiPoint':
             instance = "MultiPoint Instance"
             qty = len(self.geoms)
-            return "<{} {} Points>".format(instance, qty)
+            return "<{0} {1} Points>".format(instance, qty)
         elif self._type == 'MultiLineString':
             instance = "MultiLineString Instance"
             qty = len(self._geoms)
             bounds = self.bounds
-            return "<{} {} Lines {} bbox>".format(instance, qty, bounds)
+            return "<{0} {1} Lines {2} bbox>".format(instance, qty, bounds)
         elif self._type == 'MultiPolygon':
             instance = "MultiPolygon Instance"
             qty = len(self._geoms)
             bounds = self.bounds
-            return "<{} {} Polygons {} bbox>".format(instance, qty, bounds)
+            return "<{0} {1} Polygons {2} bbox>".format(instance, qty, bounds)
         elif self._type == 'GeometryCollection':
             instance = "GeometryCollection Instance"
             qty = len(self._geoms)
             bounds = self.bounds
-            return "<{} {} Geometries {} bbox>".format(instance, qty, bounds)
+            return "<{0} {1} Geometries {2} bbox>".format(
+                instance, qty, bounds)
         else:
             return object.__repr__(self)
 

--- a/pygeoif/test_main.py
+++ b/pygeoif/test_main.py
@@ -504,6 +504,7 @@ class AsShapeTestCase(unittest.TestCase):
         f = geometry.MultiLineString([[[0.0, 0.0], [1.0, 2.0]]])
         s = geometry.as_shape(f)
         self.assertEqual(f.__geo_interface__, s.__geo_interface__)
+        self.assertEqual((0, 0, 1, 2), f.bounds)
 
     def test_multipolygon(self):
         f = geometry.MultiPolygon([(((0.0, 0.0), (0.0, 1.0), (1.0, 1.0),
@@ -625,12 +626,54 @@ class OrientationTestCase(unittest.TestCase):
         self.assertEqual(list(interiors[1].coords), int_2)
 
 
+class ReprMethodTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.feature = geometry._Feature()
+        self.point = geometry.Point(0, 1)
+        self.linestring = geometry.LineString([[0, 0], [1, 0], [1, 1]])
+        self.linearring = geometry.LinearRing([[0, 0], [1, 0], [1, 1],
+                                               [0, 0]])
+        self.coords_1 = ((0., 0.), (0., 1.), (1., 1.), (1., 0.), (0., 0.))
+        self.polygon = geometry.Polygon(self.coords_1)
+        self.multipoint = geometry.MultiPoint([[0.0, 0.0], [1.0, 2.0]])
+        self.multiline = geometry.MultiLineString([[[0.0, 0.0], [1.0, 2.0]]])
+        self.multipoly = geometry.MultiPolygon([(((0.0, 0.0), (0.0, 1.0),
+                                                 (1.0, 1.0), (1.0, 0.0)),
+                                               [((0.1, 0.1), (0.1, 0.2),
+                                                 (0.2, 0.2), (0.2, 0.1))])])
+        self.geo_collect = geometry.GeometryCollection([self.point,
+                                                        self.linestring,
+                                                        self.linearring])
+
+    def test_repr(self):
+        pointchk = "Point(0.0, 1.0)"
+        l_stringchk = "<LineString Instance 3 Coords>"
+        l_ringchk = "<LinearRing Instance 4 Coords>"
+        polychk = "<Polygon Instance 0 Interior 5 Exterior>"
+        m_pointchk = "<MultiPoint Instance 2 Points>"
+        ml_stringchk = "<MultiLineString Instance 1 Lines {} bbox>".format(self.multiline.bounds)
+        m_polychk = "<MultiPolygon Instance 1 Polygons {} bbox>".format(self.multipoly.bounds)
+        gc_chk = "<GeometryCollection Instance 3 Geometries {} bbox>".format(self.geo_collect.bounds)
+        self.assertEquals(self.point.__repr__(), pointchk)
+        self.assertEquals(self.linestring.__repr__(), l_stringchk)
+        self.assertEquals(self.linearring.__repr__(), l_ringchk)
+        self.assertEquals(self.polygon.__repr__(), polychk)
+        self.assertEquals(self.multipoint.__repr__(), m_pointchk)
+        self.assertEquals(self.multiline.__repr__(), ml_stringchk)
+        self.assertEquals(self.multipoly.__repr__(), m_polychk)
+        self.assertEquals(self.geo_collect.__repr__(), gc_chk)
+        self.assertEquals(self.feature.__repr__()[0:33],
+                          '<pygeoif.geometry._Feature object')
+
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(BasicTestCase))
     suite.addTest(unittest.makeSuite(WKTTestCase))
     suite.addTest(unittest.makeSuite(AsShapeTestCase))
     suite.addTest(unittest.makeSuite(OrientationTestCase))
+    suite.addTest(unittest.makeSuite(ReprMethodTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/pygeoif/test_main.py
+++ b/pygeoif/test_main.py
@@ -652,9 +652,9 @@ class ReprMethodTestCase(unittest.TestCase):
         l_ringchk = "<LinearRing Instance 4 Coords>"
         polychk = "<Polygon Instance 0 Interior 5 Exterior>"
         m_pointchk = "<MultiPoint Instance 2 Points>"
-        ml_stringchk = "<MultiLineString Instance 1 Lines {} bbox>".format(self.multiline.bounds)
-        m_polychk = "<MultiPolygon Instance 1 Polygons {} bbox>".format(self.multipoly.bounds)
-        gc_chk = "<GeometryCollection Instance 3 Geometries {} bbox>".format(self.geo_collect.bounds)
+        ml_stringchk = "<MultiLineString Instance 1 Lines {0} bbox>".format(self.multiline.bounds)
+        m_polychk = "<MultiPolygon Instance 1 Polygons {0} bbox>".format(self.multipoly.bounds)
+        gc_chk = "<GeometryCollection Instance 3 Geometries {0} bbox>".format(self.geo_collect.bounds)
         self.assertEquals(self.point.__repr__(), pointchk)
         self.assertEquals(self.linestring.__repr__(), l_stringchk)
         self.assertEquals(self.linearring.__repr__(), l_ringchk)


### PR DESCRIPTION
Created __repr__ method for geometry types:  Point, LineString,
LinearRing, Polygon, Multipoint, MultiLineString, MultiPolygon,
GeometryCollection, and _type = None cases.

The intent of the modification is to have __repr__ return informative
string. For example, __repr__ for LineString instance will return instance
type and the number of coordinate sets associated with the object. The
__repr__ for a Point instance will return a string that allows rebuilding
of the object.

Added test_suite to verify output of geometry __repr__ calls.