### PR TITLE
Add __iter__ method to FeatureCollection and GeometryCollection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,6 +228,8 @@ Example
     >>> c.__geo_interface__
     {'type': 'GeometryCollection', 'geometries': [{'type': 'Point', 'coordinates': (1.0, -1.0)},/
     {'type': 'Point', 'coordinates': (1.0, -1.0)}]}
+    >>> [geom for geom in geoms]
+    [Point(1.0, -1.0), Point(1.0, -1.0)]
 
 Feature
 -------
@@ -263,20 +265,22 @@ features: sequence
 Example
 ~~~~~~~~
 
->>> from pygeoif import geometry
->>> p = geometry.Point(1.0, -1.0)
->>> props = {'Name': 'Sample Point', 'Other': 'Other Data'}
->>> a = geometry.Feature(p, props)
->>> p2 = geometry.Point(1.0, -1.0)
->>> props2 = {'Name': 'Sample Point2', 'Other': 'Other Data2'}
->>> b = geometry.Feature(p2, props2)
->>> features = [a, b]
->>> c = geometry.FeatureCollection(features)
->>> c.__geo_interface__
-{'type': 'FeatureCollection', 'features': [{'geometry': {'type': 'Point', 'coordinates': (1.0, -1.0)},/
- 'type': 'Feature', 'properties': {'Other': 'Other Data', 'Name': 'Sample Point'}},/
- {'geometry': {'type': 'Point', 'coordinates': (1.0, -1.0)}, 'type': 'Feature',/
- 'properties': {'Other': 'Other Data2', 'Name': 'Sample Point2'}}]}
+    >>> from pygeoif import geometry
+    >>> p = geometry.Point(1.0, -1.0)
+    >>> props = {'Name': 'Sample Point', 'Other': 'Other Data'}
+    >>> a = geometry.Feature(p, props)
+    >>> p2 = geometry.Point(1.0, -1.0)
+    >>> props2 = {'Name': 'Sample Point2', 'Other': 'Other Data2'}
+    >>> b = geometry.Feature(p2, props2)
+    >>> features = [a, b]
+    >>> c = geometry.FeatureCollection(features)
+    >>> c.__geo_interface__
+    {'type': 'FeatureCollection', 'features': [{'geometry': {'type': 'Point', 'coordinates': (1.0, -1.0)},/
+     'type': 'Feature', 'properties': {'Other': 'Other Data', 'Name': 'Sample Point'}},/
+     {'geometry': {'type': 'Point', 'coordinates': (1.0, -1.0)}, 'type': 'Feature',/
+     'properties': {'Other': 'Other Data2', 'Name': 'Sample Point2'}}]}
+    >>> [feature for feature in c]
+    [<Feature Instance Point geometry 2 properties>, <Feature Instance Point geometry 2 properties>]
 
 Functions
 =========

--- a/pygeoif/geometry.py
+++ b/pygeoif/geometry.py
@@ -956,6 +956,9 @@ class GeometryCollection(_Geometry):
         else:
             return 0
 
+    def __iter__(self):
+        return iter(self._geoms)
+
 
 class FeatureCollection(_GeoObject):
     """A heterogenous collection of Features
@@ -1035,6 +1038,9 @@ class FeatureCollection(_GeoObject):
             return len(self._features)
         else:
             return 0
+
+    def __iter__(self):
+        return iter(self._features)
 
 
 def signed_area(coords):

--- a/pygeoif/test_main.py
+++ b/pygeoif/test_main.py
@@ -301,6 +301,7 @@ class BasicTestCase(unittest.TestCase):
                           [p, f])
         mp1 = geometry.MultiPoint([p0, p1])
         self.assertRaises(ValueError, geometry.GeometryCollection, [p, mp1])
+        self.assertEqual([p, ph, p0, p1, r, l], [geom for geom in gc])
 
     def test_mapping(self):
         self.assertEqual(geometry.mapping(geometry.Point(1, 1)),
@@ -727,6 +728,7 @@ class FeatureTestCase(unittest.TestCase):
         self.assertEqual(self.fc.bounds, (0.0, 0.0, 2.0, 2.0))
         self.assertEqual(self.fc.__geo_interface__,
                          geometry.as_shape(self.fc).__geo_interface__)
+        self.assertEqual([self.f1, self.f2], [feature for feature in self.fc])
 
 
 def test_suite():


### PR DESCRIPTION
Add the __iter__ method to allow looping over the contents of a FeatureCollection or Geometry collection.  Also added some examples to the docs:

>>> [geom for geom in geoms]
[Point(1.0, -1.0), Point(1.0, -1.0)]

>>> [feature for feature in c]
[<Feature Instance Point geometry 2 properties>, <Feature Instance Point geometry 2 properties>]

This allows you to loop over the Feature and Geometry objects contained in _features and _geoms without doing the following:

 [geom for geom in geoms._geoms]