### PR TITLE
add "bbox" to __geo_interface__ output

### DIFF
--- a/pygeoif/geometry.py
+++ b/pygeoif/geometry.py
@@ -160,6 +160,7 @@ class Feature(_GeoObject):
     @property
     def __geo_interface__(self):
         geo_interface = {'type': self._type,
+                         'bbox': self._geometry.bounds,
                          'geometry': self._geometry.__geo_interface__,
                          'properties': self._properties
                          }
@@ -292,6 +293,7 @@ class LineString(_Geometry):
         if self._type and self._geoms:
             return {
                 'type': self._type,
+                'bbox': self.bounds,
                 'coordinates': tuple(self.coords)
             }
 
@@ -449,11 +451,13 @@ class Polygon(_Geometry):
                 coords.append(hole.coords)
             return {
                 'type': self._type,
+                'bbox': self.bounds,
                 'coordinates': tuple(coords)
             }
         elif self._exterior:
             return {
                 'type': self._type,
+                'bbox': self.bounds,
                 'coordinates': (self._exterior.coords,)
             }
 
@@ -570,6 +574,7 @@ class MultiPoint(_Geometry):
     def __geo_interface__(self):
         return {
             'type': self._type,
+            'bbox': self.bounds,
             'coordinates': tuple([g.coords[0] for g in self._geoms])
         }
 
@@ -681,6 +686,7 @@ class MultiLineString(_Geometry):
     def __geo_interface__(self):
         return {
             'type': self._type,
+            'bbox': self.bounds,
             'coordinates': tuple(
                 tuple(c for c in g.coords) for g in self.geoms
             )
@@ -780,6 +786,7 @@ class MultiPolygon(_Geometry):
             allcoords.append(tuple(coords))
         return {
             'type': self._type,
+            'bbox': self.bounds,
             'coordinates': tuple(allcoords)
         }
 
@@ -1008,7 +1015,9 @@ class FeatureCollection(_GeoObject):
         gifs = []
         for feature in self._features:
             gifs.append(feature.__geo_interface__)
-        return {'type': self._type, 'features': gifs}
+        return {'type': self._type,
+                'bbox': self.bounds,
+                'features': gifs}
 
     def __init__(self, features):
         self._features = []

--- a/pygeoif/test_main.py
+++ b/pygeoif/test_main.py
@@ -65,6 +65,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(l.bounds, (0.0, 0.0, 1.0, 1.0))
         self.assertEqual(l.__geo_interface__,
                          {'type': 'LineString',
+                          'bbox': (0.0, 0.0, 1.0, 1.0),
                           'coordinates': ((0.0, 0.0), (1.0, 1.0))})
         self.assertEqual(l.to_wkt(), 'LINESTRING (0.0 0.0, 1.0 1.0)')
         p = geometry.Point(0, 0)
@@ -97,6 +98,7 @@ class BasicTestCase(unittest.TestCase):
         l = geometry.LineString(r)
         self.assertEqual(l.coords, ((0, 0), (1, 1), (1, 0), (0, 0)))
         self.assertEqual(r.__geo_interface__, {'type': 'LinearRing',
+                                               'bbox': (0.0, 0.0, 1.0, 1.0),
                                                'coordinates': ((0.0, 0.0),
                                                                (1.0, 1.0),
                                                                (1.0, 0.0),
@@ -117,9 +119,10 @@ class BasicTestCase(unittest.TestCase):
     def test_polygon(self):
         p = geometry.Polygon([(0, 0), (1, 1), (1, 0), (0, 0)])
         self.assertEqual(p.exterior.coords, ((0.0, 0.0), (1.0, 1.0),
-                                            (1.0, 0.0), (0.0, 0.0)))
+                                             (1.0, 0.0), (0.0, 0.0)))
         self.assertEqual(list(p.interiors), [])
         self.assertEqual(p.__geo_interface__, {'type': 'Polygon',
+                                               'bbox': (0.0, 0.0, 1.0, 1.0),
                                                'coordinates': (((0.0, 0.0),
                                                                 (1.0, 1.0),
                                                                 (1.0, 0.0),
@@ -136,6 +139,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(ph1.exterior.coords, tuple(e))
         self.assertEqual(list(ph1.interiors)[0].coords, tuple(i))
         self.assertEqual(ph1.__geo_interface__, {'type': 'Polygon',
+                                                 'bbox': (0.0, 0.0, 2.0, 2.0),
                                                  'coordinates': (((0.0, 0.0),
                                                                   (0.0, 2.0),
                                                                   (2.0, 2.0),
@@ -157,6 +161,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(list(ph2.interiors)[0].coords, tuple(int_1))
         self.assertEqual(list(ph2.interiors)[1].coords, tuple(int_2))
         self.assertEqual(ph2.__geo_interface__, {'type': 'Polygon',
+                                                 'bbox': (0.0, 0.0, 2.0, 2.0),
                                                  'coordinates': (((0.0, 0.0),
                                                                   (0.0, 2.0),
                                                                   (2.0, 2.0),
@@ -229,6 +234,10 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(mp6.bounds, (0.0, 0.0, 1.0, 1.0))
         self.assertRaises(TypeError, geometry.MultiPoint, [0, 0])
         self.assertRaises(TypeError, geometry.MultiPoint, 0,)
+        self.assertEqual(mp1.__geo_interface__,
+                         {'type': 'MultiPoint',
+                          'bbox': (0.0, 0.0, 2.0, 2.0),
+                          'coordinates': ((0.0, 0.0), (1.0, 1.0), (2.0, 2.0))})
 
     def test_multilinestring(self):
         ml = geometry.MultiLineString([[[0.0, 0.0], [1.0, 2.0]]])
@@ -263,6 +272,17 @@ class BasicTestCase(unittest.TestCase):
                                                      (0.2, 0.2), (0.2, 0.1))]
                                      )
                                     ])
+        self.assertEqual(mp.__geo_interface__,
+                         {'type': 'MultiPolygon',
+                          'bbox': (0.0, 0.0, 1.0, 1.0),
+                          'coordinates': ((((0.0, 0.0), (0.0, 1.0),
+                                            (1.0, 1.0), (1.0, 0.0),
+                                            (0.0, 0.0)
+                                            ),
+                                           ((0.1, 0.1), (0.1, 0.2),
+                                            (0.2, 0.2), (0.2, 0.1),
+                                            (0.1, 0.1))),)
+                          })
         self.assertEqual(len(mp.geoms), 1)
         self.assertTrue(isinstance(mp.geoms[0], geometry.Polygon))
         mp1 = geometry.MultiPolygon(mp)
@@ -442,6 +462,7 @@ class WKTTestCase(unittest.TestCase):
         p = geometry.from_wkt("MULTIPOLYGON (((30 20, 10 40, 45 40, 30 20)),"
                               "((15 5, 40 10, 10 20, 5 10, 15 5)))")
         self.assertEqual(p.__geo_interface__, {'type': 'MultiPolygon',
+                                               'bbox': (5.0, 5.0, 45.0, 40.0),
                                                'coordinates':
                         ((((30.0, 20.0), (10.0, 40.0), (45.0, 40.0),
                            (30.0, 20.0)),), (((15.0, 5.0), (40.0, 10.0),
@@ -701,7 +722,9 @@ class FeatureTestCase(unittest.TestCase):
                          geometry.as_shape(self.f1).__geo_interface__)
         self.assertEqual(self.f1.__geo_interface__,
                          {'type': 'Feature',
+                          'bbox': (0.0, 0.0, 1.0, 1.0),
                           'geometry': {'type': 'Polygon',
+                                       'bbox': (0.0, 0.0, 1.0, 1.0),
                                        'coordinates': (((0.0, 0.0), (0.0, 1.0),
                                                         (1.0, 1.0), (1.0, 0.0),
                                                         (0.0, 0.0)),),
@@ -712,7 +735,9 @@ class FeatureTestCase(unittest.TestCase):
         self.f1.properties['coords']['cube'] = (0, 0, 0)
         self.assertEqual(self.f1.__geo_interface__,
                          {'type': 'Feature',
+                          'bbox': (0.0, 0.0, 1.0, 1.0),
                           'geometry': {'type': 'Polygon',
+                                       'bbox': (0.0, 0.0, 1.0, 1.0),
                                        'coordinates': (((0.0, 0.0), (0.0, 1.0),
                                                         (1.0, 1.0), (1.0, 0.0),
                                                         (0.0, 0.0)),),
@@ -726,7 +751,9 @@ class FeatureTestCase(unittest.TestCase):
         self.assertEqual(self.f3.id, '1')
         self.assertEqual(self.f3.__geo_interface__,
                          {'type': 'Feature',
+                          'bbox': (0.0, 0.0, 1.0, 1.0),
                           'geometry': {'type': 'Polygon',
+                                       'bbox': (0.0, 0.0, 1.0, 1.0),
                                        'coordinates': (((0.0, 0.0), (0.0, 1.0),
                                                         (1.0, 1.0), (1.0, 0.0),
                                                         (0.0, 0.0)),),


### PR DESCRIPTION
 http://www.geojson.org/geojson-spec.html#bounding-boxes

Most geometry and feature objects already had a bound method to determine the bounding box coordinates but the coordinates were not being added to the __geo_interface__ output under the "bbox" member.

It is unclear what is the proper way to handle the "bbox" member for points.  Can/should a point have a bbox?  Since the bbox member is optional I am omitting it from point objects.