### PR TITLE
Parses WKT that is not in upper case

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 0.8 (unreleased)
 -----------------
 
+- Parses WKT that is not in upper case.
 
 
 0.7 (2017/05/04)

--- a/pygeoif/geometry.py
+++ b/pygeoif/geometry.py
@@ -1184,7 +1184,7 @@ def from_wkt(geo_str):
     Create a geometry from its WKT representation
     """
 
-    wkt = geo_str.strip()
+    wkt = geo_str.upper().strip()
     wkt = ' '.join([l.strip() for l in wkt.splitlines()])
     wkt = wkt_regex.match(wkt).group('wkt')
     ftype = wkt_regex.match(wkt).group('type')

--- a/pygeoif/test_main.py
+++ b/pygeoif/test_main.py
@@ -360,14 +360,15 @@ class WKTTestCase(unittest.TestCase):
 
 
     def test_point(self):
-        p = geometry.from_wkt('POINT (0.0 1.0)')
-        self.assertEqual(isinstance(p, geometry.Point), True)
-        self.assertEqual(p.x, 0.0)
-        self.assertEqual(p.y, 1.0)
-        self.assertEqual(p.to_wkt(), 'POINT (0.0 1.0)')
-        self.assertEqual(p.to_wkt(), p.wkt)
-        self.assertEqual(str(p), 'POINT (0.0 1.0)')
-        self.assertEqual(p.geom_type, 'Point')
+        for wkt in ['POINT (0.0 1.0)', 'POINT(0.0 1.0)', 'Point(0.0 1.0)', 'Point (0.0 1.0)']:
+            p = geometry.from_wkt(wkt)
+            self.assertEqual(isinstance(p, geometry.Point), True)
+            self.assertEqual(p.x, 0.0)
+            self.assertEqual(p.y, 1.0)
+            self.assertEqual(p.to_wkt(), 'POINT (0.0 1.0)')
+            self.assertEqual(p.to_wkt(), p.wkt)
+            self.assertEqual(str(p), 'POINT (0.0 1.0)')
+            self.assertEqual(p.geom_type, 'Point')
 
     def test_linestring(self):
         l = geometry.from_wkt('LINESTRING(-72.991 46.177,-73.079 46.16,'


### PR DESCRIPTION
Allows to parse bad WKT like `Point (1 -1)`