### PR TITLE
Adding Power support(ppc64le) with continuous integration/testing to the project stays architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 language: python
 sudo: false
+arch:
+- amd64
+- ppc64le
+sudo: false
 python:
 - '3.5'
-- '3.3'
 - '3.4'
-- '2.7'
-- '2.6'
-- pypy
-- pypy3
+jobs:
+  include:
+   - arch : amd64
+     python : '2.7'
+     dist: bionic
+   - arch : amd64
+     python : pypy3
+   - arch : ppc64le
+     dist: bionic
+     python : '2.7'
 install:
 - pip install coveralls
 - pip install pep8


### PR DESCRIPTION
I am part of IBM team and working on porting power arch to packages as continuous integration & testing.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly,
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.
Pls verify and merge

