### PR TITLE
added force_2d factory and move_coordinates function #180

### DIFF
--- a/pygeoif/factories.py
+++ b/pygeoif/factories.py
@@ -24,6 +24,7 @@ from typing import Union
 from typing import cast
 
 from pygeoif.exceptions import WKTParserError
+from pygeoif.functions import move_coordinates
 from pygeoif.functions import signed_area
 from pygeoif.geometry import Geometry
 from pygeoif.geometry import GeometryCollection
@@ -58,6 +59,36 @@ gcre: Pattern[str] = re.compile(r"POINT|LINESTRING|LINEARRING|POLYGON")
 outer: Pattern[str] = re.compile(r"\((.+)\)")
 inner: Pattern[str] = re.compile(r"\([^)]*\)")
 mpre: Pattern[str] = re.compile(r"\(\((.+?)\)\)")
+
+
+def force_2d(
+    context: Union[GeoType, GeoCollectionType],
+) -> Union[Geometry, GeometryCollection]:
+    """
+    Force the dimensionality of a geometry to 2D.
+
+    >>> force_2d(Point(0, 0, 1))
+    Point(0, 0)
+    >>> force_2d(Point(0, 0))
+    Point(0, 0)
+    >>> force_2d(LineString([(0, 0, 0), (0, 1, 1), (1, 1, 2)]))
+    LineString(((0, 0), (0, 1), (1, 1)))
+    """
+    geometry = context if isinstance(context, dict) else mapping(context)
+    if not geometry:
+        msg = "Object does not implement __geo_interface__"
+        raise TypeError(msg)
+    if geometry["type"] == "GeometryCollection":
+        return GeometryCollection(
+            force_2d(g)  # type: ignore [arg-type]
+            for g in geometry["geometries"]  # type: ignore [typeddict-item]
+        )
+
+    geometry["coordinates"] = move_coordinates(  # type: ignore [typeddict-unknown-key]
+        geometry["coordinates"],  # type: ignore [typeddict-item]
+        (0, 0),  
+    )
+    return shape(geometry)
 
 
 def get_oriented_ring(ring: LineType, ccw: bool) -> LineType:  # noqa: FBT001

--- a/pygeoif/factories.py
+++ b/pygeoif/factories.py
@@ -86,7 +86,7 @@ def force_2d(
 
     geometry["coordinates"] = move_coordinates(  # type: ignore [typeddict-unknown-key]
         geometry["coordinates"],  # type: ignore [typeddict-item]
-        (0, 0),  
+        (0, 0),
     )
     return shape(geometry)
 

--- a/pygeoif/functions.py
+++ b/pygeoif/functions.py
@@ -19,8 +19,10 @@
 import math
 from itertools import groupby
 from itertools import zip_longest
+from typing import Any
 from typing import Iterable
 from typing import List
+from typing import Sequence
 from typing import Tuple
 from typing import Union
 from typing import cast
@@ -188,11 +190,60 @@ def compare_geo_interface(
         return False
 
 
+def move_coordinate(
+    coordinate: Sequence[float],
+    move_by: Sequence[float],
+    z: float = 0,
+) -> Tuple[float, ...]:
+    """
+    Move the coordinate by the given vector.
+
+    This forcefully changes the dimensions of the coordinate to match the latter.
+    >>> move_coordinate((0, 0), (-1, 1))
+    (-1, 1)
+    >>> move_coordinate((0, 0, 0), (-1, 1))
+    (-1, 1)
+    >>> move_coordinate((0, 0), (-1, 1, 0))
+    (-1, 1, 0)
+    """
+    if len(coordinate) > len(move_by):
+        return tuple(c + m for c, m in zip(coordinate, move_by))
+    return tuple(c + m for c, m in zip_longest(coordinate, move_by, fillvalue=z))
+
+
+def move_coordinates(
+    coordinates: Sequence[Any],
+    move_by: Sequence[float],
+    z: float = 0,
+) -> Sequence[Any]:
+    """
+    Move the coordinates recursively by the given vector.
+
+    This forcefully changes the dimension of each of the coordinate to match
+    the dimension of the vector.
+    >>> move_coordinates(((0, 0), (-1, 1)), (-1, 1))
+    ((-1, 1), (-2, 2))
+    >>> move_coordinates(((0, 0, 0), (-1, 1, 0)), (-1, 1))
+    ((-1, 1), (-2, 2))
+    >>> move_coordinates(((0, 0), (-1, 1)), (-1, 1, 0))
+    ((-1, 1, 0), (-2, 2, 0))
+    """
+    if isinstance(coordinates, (tuple, list)) and isinstance(
+        coordinates[0],
+        (int, float),
+    ):
+        # coordinates is just a list of numbers, i.e. represents a single coordinate
+        return move_coordinate(coordinates, move_by, z)
+    return tuple(move_coordinates(c, move_by, z) for c in coordinates)
+
+
 __all__ = [
     "centroid",
     "compare_coordinates",
     "compare_geo_interface",
     "convex_hull",
     "dedupe",
+    "move_coordinate",
+    "move_coordinates",
     "signed_area",
 ]

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -77,7 +77,11 @@ def test_force_2d_multilinestring() -> None:
     # 3d multi line string to 2d multi line string
     mls = geometry.MultiLineString([[(1, 2, 3), (4, 5, 6)], [(7, 8, 9), (10, 11, 12)]])
     mls2d = factories.force_2d(mls)
-    assert list(mls2d.geoms) == [geometry.LineString([(1, 2), (4, 5)]), geometry.LineString([(7, 8), (10, 11)])]
+    assert list(mls2d.geoms) == [
+        geometry.LineString([(1, 2), (4, 5)]),
+        geometry.LineString([(7, 8), (10, 11)]),
+    ]
+
 
 def test_force_2d_polygon() -> None:
     # 2d to 2d (no actual change)
@@ -85,9 +89,7 @@ def test_force_2d_polygon() -> None:
     internal = [(0.5, 0.5), (0.5, 1.5), (1.5, 1.5), (1.5, 0.5), (0.5, 0.5)]
     p = geometry.Polygon(external, [internal])
     p2d = factories.force_2d(p)
-    assert p2d.coords[0] == (
-        ((0, 0), (0, 2), (2, 2), (2, 0), (0, 0))
-    )
+    assert p2d.coords[0] == (((0, 0), (0, 2), (2, 2), (2, 0), (0, 0)))
     assert p2d.coords[1] == (
         ((0.5, 0.5), (0.5, 1.5), (1.5, 1.5), (1.5, 0.5), (0.5, 0.5)),
     )
@@ -96,13 +98,17 @@ def test_force_2d_polygon() -> None:
 
     # 3d to 2d
     external = [(0, 0, 1), (0, 2, 1), (2, 2, 1), (2, 0, 1), (0, 0, 1)]
-    internal = [(0.5, 0.5, 1), (0.5, 1.5, 1), (1.5, 1.5, 1), (1.5, 0.5, 1), (0.5, 0.5, 1)]
+    internal = [
+        (0.5, 0.5, 1),
+        (0.5, 1.5, 1),
+        (1.5, 1.5, 1),
+        (1.5, 0.5, 1),
+        (0.5, 0.5, 1),
+    ]
 
     p = geometry.Polygon(external, [internal])
     p2d = factories.force_2d(p)
-    assert p2d.coords[0] == (
-        ((0, 0), (0, 2), (2, 2), (2, 0), (0, 0))
-    )
+    assert p2d.coords[0] == (((0, 0), (0, 2), (2, 2), (2, 0), (0, 0)))
     assert p2d.coords[1] == (
         ((0.5, 0.5), (0.5, 1.5), (1.5, 1.5), (1.5, 0.5), (0.5, 0.5)),
     )
@@ -126,7 +132,9 @@ def test_force2d_collection() -> None:
     assert list(gc2d.geoms) == list(gc.geoms)
 
     # 3d to 2d
-    gc = geometry.GeometryCollection([geometry.Point(-1, 1, 0), geometry.Point(-2, 2, 0)])
+    gc = geometry.GeometryCollection(
+        [geometry.Point(-1, 1, 0), geometry.Point(-2, 2, 0)],
+    )
     gc2d = factories.force_2d(gc)
     assert list(gc2d.geoms) == [geometry.Point(-1, 1), geometry.Point(-2, 2)]
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -21,6 +21,116 @@ def test_num_float() -> None:
     assert isinstance(factories.num("1.1"), float)
 
 
+def test_force_2d_point() -> None:
+    # 2d point to 2d point (no actual change)
+    p = geometry.Point(-1, 1)
+    p2d = factories.force_2d(p)
+    assert p2d.x == -1
+    assert p2d.y == 1
+    assert not p2d.has_z
+
+    # 3d point to 2d point
+    p = geometry.Point(-1, 1, 2)
+    p2d = factories.force_2d(p)
+    assert p2d.x == -1
+    assert p2d.y == 1
+    assert not p2d.has_z
+
+
+def test_force_2d_multipoint() -> None:
+    # 2d to 2d (no actual change)
+    p = geometry.MultiPoint([(-1, 1), (2, 3)])
+    p2d = factories.force_2d(p)
+    assert list(p2d.geoms) == [geometry.Point(-1, 1), geometry.Point(2, 3)]
+
+
+def test_force_2d_linestring() -> None:
+    # 2d line string to 2d line string (no actual change)
+    ls = geometry.LineString([(1, 2), (3, 4)])
+    l2d = factories.force_2d(ls)
+    assert l2d.coords == ((1, 2), (3, 4))
+
+    # 3d line string to 2d line string
+    ls = geometry.LineString([(1, 2, 3), (4, 5, 6)])
+    l2d = factories.force_2d(ls)
+    assert l2d.coords == ((1, 2), (4, 5))
+
+
+def test_force_2d_linearring() -> None:
+    # 2d linear ring to 2d linear ring (no actual change)
+    r = geometry.LinearRing([(1, 2), (3, 4)])
+    r2d = factories.force_2d(r)
+    assert r2d.coords == ((1, 2), (3, 4), (1, 2))
+
+    # 3d linear ring to 2d linear ring
+    r = geometry.LinearRing([(1, 2, 3), (4, 5, 6)])
+    r2d = factories.force_2d(r)
+    assert r2d.coords == ((1, 2), (4, 5), (1, 2))
+
+
+def test_force_2d_multilinestring() -> None:
+    # 2d multi line string to 2d multi line string (no actual change)
+    mls = geometry.MultiLineString([[(1, 2), (3, 4)], [(5, 6), (7, 8)]])
+    mls2d = factories.force_2d(mls)
+    assert list(mls2d.geoms) == list(mls.geoms)
+
+    # 3d multi line string to 2d multi line string
+    mls = geometry.MultiLineString([[(1, 2, 3), (4, 5, 6)], [(7, 8, 9), (10, 11, 12)]])
+    mls2d = factories.force_2d(mls)
+    assert list(mls2d.geoms) == [geometry.LineString([(1, 2), (4, 5)]), geometry.LineString([(7, 8), (10, 11)])]
+
+def test_force_2d_polygon() -> None:
+    # 2d to 2d (no actual change)
+    external = [(0, 0), (0, 2), (2, 2), (2, 0), (0, 0)]
+    internal = [(0.5, 0.5), (0.5, 1.5), (1.5, 1.5), (1.5, 0.5), (0.5, 0.5)]
+    p = geometry.Polygon(external, [internal])
+    p2d = factories.force_2d(p)
+    assert p2d.coords[0] == (
+        ((0, 0), (0, 2), (2, 2), (2, 0), (0, 0))
+    )
+    assert p2d.coords[1] == (
+        ((0.5, 0.5), (0.5, 1.5), (1.5, 1.5), (1.5, 0.5), (0.5, 0.5)),
+    )
+    assert not p2d.has_z
+    assert p.maybe_valid == p2d.maybe_valid
+
+    # 3d to 2d
+    external = [(0, 0, 1), (0, 2, 1), (2, 2, 1), (2, 0, 1), (0, 0, 1)]
+    internal = [(0.5, 0.5, 1), (0.5, 1.5, 1), (1.5, 1.5, 1), (1.5, 0.5, 1), (0.5, 0.5, 1)]
+
+    p = geometry.Polygon(external, [internal])
+    p2d = factories.force_2d(p)
+    assert p2d.coords[0] == (
+        ((0, 0), (0, 2), (2, 2), (2, 0), (0, 0))
+    )
+    assert p2d.coords[1] == (
+        ((0.5, 0.5), (0.5, 1.5), (1.5, 1.5), (1.5, 0.5), (0.5, 0.5)),
+    )
+    assert not p2d.has_z
+
+
+def test_force_2d_multipolygon() -> None:
+    # 2d to 2d (no actual change)
+    external = [(0, 0), (0, 2), (2, 2), (2, 0), (0, 0)]
+    internal = [(0.5, 0.5), (0.5, 1.5), (1.5, 1.5), (1.5, 0.5), (0.5, 0.5)]
+    mp = geometry.MultiPolygon([(external, [internal]), (external, [internal])])
+    mp2d = factories.force_2d(mp)
+
+    assert list(mp2d.geoms) == list(mp.geoms)
+
+
+def test_force2d_collection() -> None:
+    # 2d to 2d (no actual change)
+    gc = geometry.GeometryCollection([geometry.Point(-1, 1), geometry.Point(-2, 2)])
+    gc2d = factories.force_2d(gc)
+    assert list(gc2d.geoms) == list(gc.geoms)
+
+    # 3d to 2d
+    gc = geometry.GeometryCollection([geometry.Point(-1, 1, 0), geometry.Point(-2, 2, 0)])
+    gc2d = factories.force_2d(gc)
+    assert list(gc2d.geoms) == [geometry.Point(-1, 1), geometry.Point(-2, 2)]
+
+
 def test_orient_true() -> None:
     ext = [(0, 0), (0, 2), (2, 2), (2, 0), (0, 0)]
     int_1 = [(0.5, 0.25), (1.5, 0.25), (1.5, 1.25), (0.5, 1.25), (0.5, 0.25)]


### PR DESCRIPTION
new version of #183 

I refactored `force_2d` by using `__geo_interface__`, like functions `compare_geo_interface` and `shape` do. This is much simpler and I think that's what you were looking for.

I also added `move_coordinate` and `move_coordinates` functions.

If this is OK, I will proceed with `force_3d`