### PR TITLE
move_coordinates supports generators

### DIFF
--- a/pygeoif/functions.py
+++ b/pygeoif/functions.py
@@ -17,6 +17,7 @@
 #
 """Functions for geometries."""
 import math
+from collections.abc import Generator
 from itertools import groupby
 from itertools import zip_longest
 from typing import Iterable
@@ -229,6 +230,10 @@ def move_coordinates(
     >>> move_coordinates(((0, 0), (-1, 1)), (-1, 1, 0))
     ((-1, 1, 0), (-2, 2, 0))
     """
+    if isinstance(coordinates, Generator):
+        return (  # type: ignore [unreachable]
+            move_coordinates(x, move_by) for x in coordinates
+        )
     if isinstance(coordinates[0], (int, float)):
         return move_coordinate(cast(PointType, coordinates), move_by)
     return cast(

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,8 +2,8 @@
 import itertools
 import math
 import random
-from typing import Tuple
 from collections.abc import Generator
+from typing import Tuple
 
 import pytest
 
@@ -12,8 +12,8 @@ from pygeoif.functions import compare_coordinates
 from pygeoif.functions import compare_geo_interface
 from pygeoif.functions import convex_hull
 from pygeoif.functions import dedupe
-from pygeoif.functions import signed_area
 from pygeoif.functions import move_coordinates
+from pygeoif.functions import signed_area
 
 
 def circle_ish(x, y, r, steps):
@@ -464,10 +464,11 @@ def test_move_coordinates() -> None:
 
 
 def test_move_coordinates_diff_dimenstions() -> None:
-    coords = ((0, 0), )
+    coords = ((0, 0),)
     moved_coords = move_coordinates(coords, (0, 0, 0))
 
     assert moved_coords == ((0, 0, 0),)
+
 
 def test_move_coordinates_generator() -> None:
     coords = ((i, i + 1) for i in range(10))

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -3,6 +3,7 @@ import itertools
 import math
 import random
 from typing import Tuple
+from collections.abc import Generator
 
 import pytest
 
@@ -12,6 +13,7 @@ from pygeoif.functions import compare_geo_interface
 from pygeoif.functions import convex_hull
 from pygeoif.functions import dedupe
 from pygeoif.functions import signed_area
+from pygeoif.functions import move_coordinates
 
 
 def circle_ish(x, y, r, steps):
@@ -452,3 +454,24 @@ def test_compare_neq_empty_geo_interface() -> None:
     }
 
     assert compare_geo_interface(geo_if, {}) is False
+
+
+def test_move_coordinates() -> None:
+    coords = ((0, 0), (1, 1))
+    moved_coords = move_coordinates(coords, (1, 1))
+
+    assert moved_coords == ((1, 1), (2, 2))
+
+
+def test_move_coordinates_diff_dimenstions() -> None:
+    coords = ((0, 0), )
+    moved_coords = move_coordinates(coords, (0, 0, 0))
+
+    assert moved_coords == ((0, 0, 0),)
+
+def test_move_coordinates_generator() -> None:
+    coords = ((i, i + 1) for i in range(10))
+    moved_coords = move_coordinates(coords, (1, 1))
+
+    assert isinstance(moved_coords, Generator)
+    assert list(moved_coords) == list((i + 1, i + 2) for i in range(10))


### PR DESCRIPTION
You can now pass generator to `move_coordinates` like this:
```python
    coords = ((i, i + 1) for i in range(10))
    moved_coords = move_coordinates(coords, (1, 1))
```

That creates a small problem for mypy, as `LineType` is a `Sequence`, not `Iterable`. So probably to make typing concise we should make `LineType` an `Iterable`, or to introduce new type.