### PR TITLE
Use newer pyproject metadata licensing specifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,13 @@ keywords = [
     "Spatial",
     "WKT",
 ]
+license = "LGPL-2.1-or-later"
+license-files = [
+    "LICENSE",
+    "docs/LICENSE.rst",
+]
 name = "pygeoif"
 requires-python = ">=3.9"
-license = "LGPL-2.1-or-later"
-license-files = ["LICENSE","docs/LICENSE.rst"]
 
 [project.optional-dependencies]
 complexity = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Hypothesis",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -43,9 +42,8 @@ keywords = [
 ]
 name = "pygeoif"
 requires-python = ">=3.9"
-
-[project.license]
-text = "LGPL"
+license = "LGPL-2.1-or-later"
+license-files = ["LICENSE","docs/LICENSE.rst"]
 
 [project.optional-dependencies]
 complexity = [


### PR DESCRIPTION
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `pyproject.toml` to use newer licensing specifications with `license` and `license-files` fields.
> 
>   - **Licensing**:
>     - Update `license` field in `pyproject.toml` to `"LGPL-2.1-or-later"`.
>     - Add `license-files` field with `"LICENSE"` and `"docs/LICENSE.rst"`.
>     - Remove `project.license` section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cleder%2Fpygeoif&utm_source=github&utm_medium=referral)<sup> for 17e8bfe9f612247d34cdda4429ccd89bc84d6962. You can [customize](https://app.ellipsis.dev/cleder/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project licensing metadata to LGPL-2.1-or-later format with explicit license file references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->