### PR TITLE
docs: add auto-generated code documentation

### DIFF
--- a/docs/codedocs/api-reference/exceptions.md
+++ b/docs/codedocs/api-reference/exceptions.md
@@ -1,0 +1,78 @@
+---
+title: "Exceptions"
+description: "Reference for the custom exception types exported by pygeoif.exceptions."
+---
+
+`pygeoif.exceptions` defines the small set of custom exception classes raised across the package.
+
+Import path: `from pygeoif.exceptions import DimensionError, InvalidGeometryError, WKTParserError`
+
+## Exception Classes
+
+### `DimensionError`
+
+```python
+class DimensionError(ValueError)
+```
+
+Raised when geometry dimensionality is inconsistent or unsupported. Common cases include accessing `.z` on a 2D point or mixing 2D and 3D coordinates in one `LineString`.
+
+### `WKTParserError`
+
+```python
+class WKTParserError(AttributeError)
+```
+
+Raised by `from_wkt()` when the input WKT is unsupported or cannot be parsed successfully.
+
+### `InvalidGeometryError`
+
+```python
+class InvalidGeometryError(ValueError)
+```
+
+Declared as part of the public API for invalid geometry cases. In the current source it is exported but not heavily used by the core constructors.
+
+## Examples
+
+Handling dimensional errors:
+
+```python
+from pygeoif import Point
+from pygeoif.exceptions import DimensionError
+
+try:
+    print(Point(1, 2).z)
+except DimensionError as exc:
+    print(exc)
+```
+
+Handling parse failures:
+
+```python
+from pygeoif import from_wkt
+from pygeoif.exceptions import WKTParserError
+
+try:
+    from_wkt("POINT broken")
+except WKTParserError as exc:
+    print(exc)
+```
+
+## Notes
+
+- `WKTParserError` subclasses `AttributeError`, which may matter if you already catch parsing-related `ValueError` elsewhere.
+- `InvalidGeometryError` is part of the public contract even though topology validation is intentionally lightweight.
+- Many invalid semantic geometries are still constructible because the library favors interoperability and lightweight value objects over heavy validation.
+
+## Source Behavior
+
+All three exception classes are declared in `pygeoif/exceptions.py` as tiny marker types with explanatory docstrings and no extra instance state. That simplicity is deliberate. The rest of the package can raise domain-specific errors without introducing a larger exception hierarchy or carrying hidden metadata. In practice, that means you should treat these exceptions as semantic signals about what failed rather than as rich structured error payloads.
+
+That also keeps the exceptions easy to catch selectively in boundary code such as parsers, import pipelines, and validation wrappers.
+
+## Related API
+
+- [Factories](/docs/api-reference/factories)
+- [Point](/docs/api-reference/point)
+- [LinearRing](/docs/api-reference/linearring)

--- a/docs/codedocs/api-reference/factories.md
+++ b/docs/codedocs/api-reference/factories.md
@@ -1,0 +1,123 @@
+---
+title: "Factories"
+description: "Reference for the public conversion and normalization helpers in pygeoif.factories."
+---
+
+`pygeoif.factories` contains the main conversion helpers that turn external representations into geometry values or normalize existing geometry objects.
+
+Import paths:
+
+- `from pygeoif import shape, mapping, from_wkt, force_2d, force_3d, orient`
+- `from pygeoif.factories import box`
+
+## Public Functions
+
+### `orient`
+
+```python
+orient(polygon: Polygon, ccw: bool = True) -> Polygon
+```
+
+Returns a new polygon whose exterior and interior rings are oriented consistently. When `ccw=True`, the exterior ring is counter-clockwise and holes are clockwise.
+
+### `box`
+
+```python
+box(minx: float, miny: float, maxx: float, maxy: float, ccw: bool = True) -> Polygon
+```
+
+Builds a rectangular polygon from a bounding box.
+
+### `shape`
+
+```python
+shape(
+    context: Union[GeoType, GeoCollectionType, GeoInterface, GeoCollectionInterface]
+) -> Union[Geometry, GeometryCollection]
+```
+
+Copies coordinates from a GeoJSON-like mapping or any object with `__geo_interface__` and returns a new geometry.
+
+### `from_wkt`
+
+```python
+from_wkt(geo_str: str) -> Optional[Union[Geometry, GeometryCollection]]
+```
+
+Parses supported WKT into a geometry object. Raises `WKTParserError` on malformed or unsupported input.
+
+### `mapping`
+
+```python
+mapping(ob: Union[GeoType, GeoCollectionType]) -> Union[GeoCollectionInterface, GeoInterface]
+```
+
+Returns the object's `__geo_interface__` mapping directly.
+
+### `force_2d`
+
+```python
+force_2d(context: Union[GeoType, GeoCollectionType]) -> Union[Geometry, GeometryCollection]
+```
+
+Drops Z values recursively by rebuilding the geometry from a moved protocol mapping.
+
+### `force_3d`
+
+```python
+force_3d(
+    context: Union[GeoType, GeoCollectionType],
+    z: float = 0,
+) -> Union[Geometry, GeometryCollection]
+```
+
+Adds Z values recursively or overwrites missing Z components with the supplied default.
+
+## Parameters
+
+| Function | Parameter | Type | Default | Description |
+|---|---|---|---|---|
+| `orient` | `polygon` | `Polygon` | — | Polygon to reorient. |
+| `orient` | `ccw` | `bool` | `True` | Exterior winding direction target. |
+| `box` | `minx`, `miny`, `maxx`, `maxy` | `float` | — | Bounding box limits. |
+| `box` | `ccw` | `bool` | `True` | Output ring winding direction. |
+| `shape` | `context` | `Union[GeoType, GeoCollectionType, GeoInterface, GeoCollectionInterface]` | — | Mapping or protocol object to copy. |
+| `from_wkt` | `geo_str` | `str` | — | WKT string to parse. |
+| `mapping` | `ob` | `Union[GeoType, GeoCollectionType]` | — | Protocol-compatible object to inspect. |
+| `force_2d` | `context` | `Union[GeoType, GeoCollectionType]` | — | Geometry or collection to normalize. |
+| `force_3d` | `context` | `Union[GeoType, GeoCollectionType]` | — | Geometry or collection to normalize. |
+| `force_3d` | `z` | `float` | `0` | Default Z value for 2D coordinates. |
+
+## Examples
+
+Converting from a mapping:
+
+```python
+from pygeoif import mapping, shape
+
+payload = {"type": "Point", "coordinates": (1, 2)}
+point = shape(payload)
+print(mapping(point))
+```
+
+Dimensional normalization:
+
+```python
+from pygeoif import LineString, force_2d, force_3d
+
+line = LineString([(0, 0), (1, 1)])
+print(force_3d(line z=10).wkt)
+print(force_2d(force_3d(line z=10)).wkt)
+```
+
+## Source Notes
+
+- `shape()` dispatches by the input mapping's `type` field.
+- `from_wkt()` uses a regular expression plus type-specific parsers for each supported geometry.
+- `force_2d()` and `force_3d()` delegate recursive coordinate work to `move_geo_interface()` in `pygeoif/functions.py`.
+
+## Related API
+
+- [Functions](/docs/api-reference/functions)
+- [Exceptions](/docs/api-reference/exceptions)
+- [Types And Protocols](/docs/api-reference/types-and-protocols)

--- a/docs/codedocs/api-reference/feature.md
+++ b/docs/codedocs/api-reference/feature.md
@@ -1,0 +1,72 @@
+---
+title: "Feature"
+description: "Reference for pygeoif.Feature, the GeoJSON-style geometry-plus-properties wrapper."
+---
+
+`Feature` wraps one geometry with a property mapping and optional identifier. It is implemented in `pygeoif/feature.py` and exported as `pygeoif.Feature`.
+
+## Signature
+
+```python
+Feature(
+    geometry: Geometry,
+    properties: Optional[dict[str, Any]] = None,
+    feature_id: Optional[Union[str, int]] = None,
+) -> None
+```
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `geometry` | `Geometry` | — | The geometry value wrapped by the feature. |
+| `properties` | `Optional[dict[str, Any]]` | `None` | Property mapping stored on the feature; defaults to an empty dict. |
+| `feature_id` | `Optional[Union[str, int]]` | `None` | Optional `id` field included in `__geo_interface__`. |
+
+## Public Properties
+
+| Name | Type | Description |
+|---|---|---|
+| `id` | `Optional[Union[str, int]]` | Returns the feature identifier. |
+| `geometry` | `Geometry` | Returns the wrapped geometry. |
+| `properties` | `dict[str, Any]` | Returns the stored properties dictionary. |
+| `__geo_interface__` | `GeoFeatureInterface` | GeoJSON-like feature mapping. |
+
+## Examples
+
+Basic usage:
+
+```python
+from pygeoif import Feature, Point
+
+feature = Feature(Point(1, 2), {"name": "sensor-a"}, feature_id="sensor-a")
+print(feature.geometry.wkt)
+print(feature.__geo_interface__)
+```
+
+Mutating properties after construction:
+
+```python
+from pygeoif import Feature, Point
+
+feature = Feature(Point(1, 2), {"status": "new"})
+feature.properties["status"] = "ready"
+
+print(feature.__geo_interface__["properties"])
+```
+
+## Notes
+
+- Equality is based on the feature's GeoJSON-like mapping, including `id`, properties, nested geometry type, and nested coordinates.
+- Properties remain mutable because `Feature` stores the original dictionary or an empty replacement dict.
+- The feature's `bbox` in `__geo_interface__` comes directly from `geometry.bounds`.
+
+## Source Behavior
+
+The implementation in `pygeoif/feature.py` is intentionally thin. The constructor stores three fields, and the protocol mapping is assembled on demand instead of cached. That design keeps `Feature` aligned with whatever geometry and properties it currently references, which is especially useful when you progressively enrich metadata in an application pipeline. The trade-off is that the feature wrapper itself is not a frozen value object the way the geometry classes are.
+
+## Related API
+
+- [FeatureCollection](/docs/api-reference/featurecollection)
+- [Types And Protocols](/docs/api-reference/types-and-protocols)
+- [Functions](/docs/api-reference/functions)

--- a/docs/codedocs/api-reference/featurecollection.md
+++ b/docs/codedocs/api-reference/featurecollection.md
@@ -1,0 +1,78 @@
+---
+title: "FeatureCollection"
+description: "Reference for pygeoif.FeatureCollection, the ordered collection of Feature objects."
+---
+
+`FeatureCollection` groups multiple `Feature` objects and serializes them as a GeoJSON-style feature collection. It is implemented in `pygeoif/feature.py` and exported as `pygeoif.FeatureCollection`.
+
+## Signature
+
+```python
+FeatureCollection(features: Sequence[Feature]) -> None
+```
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `features` | `Sequence[Feature]` | — | Ordered feature instances stored as an immutable tuple. |
+
+## Public API
+
+| Name | Type | Description |
+|---|---|---|
+| `features` | `Generator[Feature, None, None]` | Yields features in stored order. |
+| `bounds` | `Bounds` | Aggregate XY extent across member geometries. |
+| `__geo_interface__` | `GeoFeatureCollectionInterface` | GeoJSON-like feature collection mapping. |
+| `__len__()` | `int` | Number of features. |
+| `__iter__()` | `Iterator[Feature]` | Iterates over stored features. |
+
+## Examples
+
+Basic usage:
+
+```python
+from pygeoif import Feature, FeatureCollection, Point
+
+collection = FeatureCollection(
+    [
+        Feature(Point(0, 0), {"name": "a"}, feature_id=1),
+        Feature(Point(2, 3), {"name": "b"}, feature_id=2),
+    ]
+)
+
+print(len(collection))
+print(collection.bounds)
+```
+
+Combining different geometry types:
+
+```python
+from pygeoif import Feature, FeatureCollection, LineString, Point
+
+collection = FeatureCollection(
+    [
+        Feature(Point(0, 0), {"kind": "origin"}),
+        Feature(LineString([(0, 0), (3, 4)]), {"kind": "path"}),
+    ]
+)
+
+print([feature.geometry.geom_type for feature in collection])
+print(collection.__geo_interface__)
+```
+
+## Notes
+
+- Bounds are computed from `feature.geometry.bounds`, not from feature properties.
+- Equality is order-sensitive because the implementation zips features in sequence order.
+- The collection itself is immutable in structure because stored features are converted to a tuple.
+
+## Source Behavior
+
+`FeatureCollection.bounds` in `pygeoif/feature.py` aggregates bounds by zipping the `(minx, miny, maxx, maxy)` tuples from every member geometry and then taking the min or max of each column. The implementation is simple and fast for normal collections, but it assumes you are storing features with meaningful geometry bounds. In other words, `FeatureCollection` is designed as a transport and grouping layer for actual spatial data, not as a generic list container that happens to accept features.
+
+## Related API
+
+- [Feature](/docs/api-reference/feature)
+- [Types And Protocols](/docs/api-reference/types-and-protocols)
+- [Functions](/docs/api-reference/functions)

--- a/docs/codedocs/api-reference/functions.md
+++ b/docs/codedocs/api-reference/functions.md
@@ -1,0 +1,113 @@
+---
+title: "Functions"
+description: "Reference for the low-level geometry algorithms and comparison helpers in pygeoif.functions."
+---
+
+`pygeoif.functions` contains the reusable geometry algorithms used throughout the package. These are public helpers, even though most applications consume them indirectly through geometry properties or factory helpers.
+
+Import path: `from pygeoif.functions import centroid, compare_coordinates, compare_geo_interface, convex_hull, dedupe, move_coordinate, move_coordinates, signed_area`
+
+## Public Functions
+
+### `signed_area`
+
+```python
+signed_area(coords: LineType) -> float
+```
+
+Returns the signed area of a ring using an XY shoelace-style algorithm. Values greater than or equal to zero indicate counter-clockwise winding.
+
+### `centroid`
+
+```python
+centroid(coords: LineType) -> tuple[Point2D, float]
+```
+
+Returns the XY centroid and signed area for a ring-like coordinate sequence. Degenerate shapes return `(nan, nan)` plus area `0` or `nan`.
+
+### `dedupe`
+
+```python
+dedupe(coords: LineType) -> LineType
+```
+
+Removes consecutive duplicate coordinates.
+
+### `convex_hull`
+
+```python
+convex_hull(points: Iterable[Point2D]) -> LineType
+```
+
+Builds a hull from 2D points using Andrew's monotone chain algorithm.
+
+### `compare_coordinates`
+
+```python
+compare_coordinates(
+    coords: Union[float, CoordinatesType, MultiCoordinatesType],
+    other: Union[float, CoordinatesType, MultiCoordinatesType],
+) -> bool
+```
+
+Recursively compares numeric coordinates using `math.isclose()` for scalar values.
+
+### `compare_geo_interface`
+
+```python
+compare_geo_interface(
+    first: Union[GeoInterface, GeoCollectionInterface],
+    second: Union[GeoInterface, GeoCollectionInterface],
+) -> bool
+```
+
+Compares two protocol mappings, handling nested geometry collections recursively.
+
+### `move_coordinate`
+
+```python
+move_coordinate(coordinate: PointType, move_by: PointType) -> PointType
+```
+
+Translates one point tuple and forces the output dimension to match `move_by`.
+
+### `move_coordinates`
+
+```python
+move_coordinates(coordinates: CoordinatesType, move_by: PointType) -> CoordinatesType
+```
+
+Recursively translates nested coordinate sequences.
+
+## Examples
+
+Orientation and centroid helpers:
+
+```python
+from pygeoif.functions import centroid, signed_area
+
+ring = [(0, 0), (4, 0), (4, 2), (0, 2), (0, 0)]
+print(signed_area(ring))
+print(centroid(ring))
+```
+
+Recursive coordinate movement:
+
+```python
+from pygeoif.functions import move_coordinates
+
+coords = (((0, 0), (1, 1)), ((2, 2), (3, 3)))
+print(move_coordinates(coords, (10, -5, 100)))
+```
+
+## Notes
+
+- `convex_hull()` is 2D-only and expects `Point2D` inputs; 3D callers project first.
+- `compare_coordinates()` treats shape structure recursively, so mismatched nesting returns `False`.
+- `move_coordinate()` can either add or drop a Z component depending on the `move_by` vector length.
+
+## Related API
+
+- [Factories](/docs/api-reference/factories)
+- [Types And Protocols](/docs/api-reference/types-and-protocols)
+- [LinearRing](/docs/api-reference/linearring)

--- a/docs/codedocs/api-reference/geometrycollection.md
+++ b/docs/codedocs/api-reference/geometrycollection.md
@@ -1,0 +1,87 @@
+---
+title: "GeometryCollection"
+description: "Reference for pygeoif.GeometryCollection, the heterogeneous collection type for nested geometry structures."
+---
+
+`GeometryCollection` stores many geometry values, including nested collections. It is defined in `pygeoif/geometry.py` and exported as `pygeoif.GeometryCollection`.
+
+## Signature
+
+```python
+GeometryCollection(
+    geometries: Iterable[
+        Union[
+            Point,
+            LineString,
+            LinearRing,
+            Polygon,
+            MultiPoint,
+            MultiLineString,
+            MultiPolygon,
+            GeometryCollection,
+        ]
+    ]
+) -> None
+```
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `geometries` | `Iterable[Union[Geometry, GeometryCollection]]` | — | Geometry instances to store; falsey empty geometries are filtered out. |
+
+## Public API
+
+| Name | Type | Description |
+|---|---|---|
+| `geoms` | `Iterator[Geometry \| GeometryCollection]` | Yields non-empty member geometries. |
+| `has_z` | `Optional[bool]` | True if any member geometry has Z values. |
+| `is_empty` | `bool` | True when every stored member is empty. |
+| `bounds` | `tuple[float, float, float, float] \| tuple[()]` | Aggregate XY extent. |
+| `wkt` | `str` | WKT representation using `GEOMETRYCOLLECTION`. |
+| `__geo_interface__` | `GeoCollectionInterface` | GeoJSON-like mapping with a `geometries` array. |
+| `__len__()` | `int` | Number of stored members. |
+
+## Equality
+
+Unlike the simpler multi-geometry classes, `GeometryCollection` overrides `__eq__` directly. It rejects empty collections, checks the other object's `type` and member count, then compares nested protocol mappings with `compare_geo_interface()` from `pygeoif/functions.py`.
+
+## Examples
+
+Basic usage:
+
+```python
+from pygeoif import GeometryCollection, LineString, Point
+
+collection = GeometryCollection([Point(0, 0), LineString([(0, 0), (1, 1)])])
+print(len(collection))
+print(collection.__geo_interface__)
+```
+
+Nested collections:
+
+```python
+from pygeoif import GeometryCollection, MultiPoint, Point
+
+nested = GeometryCollection(
+    [
+        MultiPoint([(0, 0), (1, 1)]),
+        GeometryCollection([Point(5, 5)]),
+    ]
+)
+
+print(nested.wkt)
+print(nested.bounds)
+```
+
+## Notes
+
+- `GeometryCollection` is supported by the library but called out in the source docstring as less common in mainstream GIS workflows.
+- Empty member geometries are filtered out at construction time because the constructor keeps only truthy geometries.
+- Use this type when heterogeneity matters; otherwise prefer the specific multi-geometry class that matches your data.
+
+## Related API
+
+- [MultiPoint](/docs/api-reference/multipoint)
+- [MultiLineString](/docs/api-reference/multilinestring)
+- [MultiPolygon](/docs/api-reference/multipolygon)

--- a/docs/codedocs/api-reference/hypothesis-strategies.md
+++ b/docs/codedocs/api-reference/hypothesis-strategies.md
@@ -1,0 +1,137 @@
+---
+title: "Hypothesis Strategies"
+description: "Reference for the optional property-based testing helpers in pygeoif.hypothesis.strategies."
+---
+
+`pygeoif.hypothesis.strategies` exposes Hypothesis composite strategies for generating coordinates and geometry instances. This module is optional at install time because the base package only depends on `typing_extensions`.
+
+Import path: `from pygeoif.hypothesis.strategies import Srs, geometry_collections, line_coords, line_strings, linear_rings, multi_line_strings, multi_points, multi_polygons, point_coords, points, polygons`
+
+## Public API
+
+### `Srs`
+
+```python
+Srs(
+    name: str,
+    min_xyz: tuple[Optional[float], Optional[float], Optional[float]],
+    max_xyz: tuple[Optional[float], Optional[float], Optional[float]],
+)
+```
+
+Methods:
+
+```python
+Srs.longitudes() -> st.SearchStrategy[float]
+Srs.latitudes() -> st.SearchStrategy[float]
+Srs.elevations() -> st.SearchStrategy[float]
+```
+
+`Srs` constrains generated coordinates to a chosen coordinate range.
+
+### Composite Strategies
+
+```python
+point_coords(draw: st.DrawFn, *, srs: Optional[Srs] = None, has_z: Optional[bool] = None) -> PointType
+points(draw: st.DrawFn, *, srs: Optional[Srs] = None, has_z: Optional[bool] = None) -> Point
+line_coords(
+    draw: st.DrawFn,
+    *,
+    min_points: int,
+    max_points: Optional[int] = None,
+    srs: Optional[Srs] = None,
+    has_z: Optional[bool] = None,
+    unique: bool = False,
+) -> LineType
+line_strings(draw: st.DrawFn, *, max_points: Optional[int] = None, srs: Optional[Srs] = None, has_z: Optional[bool] = None) -> LineString
+linear_rings(draw: st.DrawFn, *, max_points: Optional[int] = None, srs: Optional[Srs] = None, has_z: Optional[bool] = None) -> LinearRing
+polygons(
+    draw: st.DrawFn,
+    *,
+    max_points: Optional[int] = None,
+    min_interiors: int = 0,
+    max_interiors: int = 5,
+    srs: Optional[Srs] = None,
+    has_z: Optional[bool] = None,
+) -> Polygon
+multi_points(
+    draw: st.DrawFn,
+    *,
+    min_points: int = 1,
+    max_points: Optional[int] = None,
+    srs: Optional[Srs] = None,
+    has_z: Optional[bool] = None,
+) -> MultiPoint
+multi_line_strings(
+    draw: st.DrawFn,
+    *,
+    min_lines: int = 1,
+    max_lines: int = 5,
+    max_points: int = 10,
+    srs: Optional[Srs] = None,
+    has_z: Optional[bool] = None,
+) -> MultiLineString
+multi_polygons(
+    draw: st.DrawFn,
+    *,
+    min_polygons: int = 1,
+    max_polygons: int = 3,
+    max_points: int = 10,
+    min_interiors: int = 0,
+    max_interiors: int = 2,
+    srs: Optional[Srs] = None,
+    has_z: Optional[bool] = None,
+) -> MultiPolygon
+geometry_collections(
+    draw: st.DrawFn,
+    *,
+    min_geoms: int = 1,
+    max_geoms: int = 5,
+    max_points: int = 20,
+    min_interiors: int = 0,
+    max_interiors: int = 5,
+    max_leaves: int = 3,
+    srs: Optional[Srs] = None,
+    has_z: Optional[bool] = None,
+) -> GeometryCollection
+```
+
+## Examples
+
+Basic usage:
+
+```python
+from hypothesis import given
+from pygeoif.hypothesis.strategies import points
+
+@given(points(has_z=False))
+def test_points_are_never_empty(point):
+    assert not point.is_empty
+```
+
+Using an `Srs` constraint:
+
+```python
+from hypothesis import given
+from pygeoif.hypothesis.strategies import Srs, point_coords
+
+srs = Srs("Bounds", (-5.0, -10.0, 0.0), (5.0, 10.0, 100.0))
+
+@given(point_coords(srs=srs, has_z=True))
+def test_local_points(coord):
+    assert -5.0 <= coord[0] <= 5.0
+    assert -10.0 <= coord[1] <= 10.0
+    assert 0.0 <= coord[2] <= 100.0
+```
+
+## Notes
+
+- Coordinates are generated as 32-bit floats to limit precision issues, as stated in the module docstring.
+- Several strategies raise `ValueError` for impossible limits such as `max_points < 2` for `line_strings()` or `max_points < 4` for `linear_rings()`.
+- The collection strategy uses `st.recursive()` to allow nested geometry collections while bounding recursion through `max_leaves`.
+
+## Related API
+
+- [Hypothesis Testing Guide](/docs/guides/hypothesis-testing)
+- [Types And Protocols](/docs/api-reference/types-and-protocols)
+- [GeometryCollection](/docs/api-reference/geometrycollection)

--- a/docs/codedocs/api-reference/linearring.md
+++ b/docs/codedocs/api-reference/linearring.md
@@ -1,0 +1,72 @@
+---
+title: "LinearRing"
+description: "Reference for pygeoif.LinearRing, the self-closing ring used by polygons."
+---
+
+`LinearRing` inherits from `LineString` and represents a closed ring. It is implemented in `pygeoif/geometry.py` and exported as `pygeoif.LinearRing`.
+
+## Signature
+
+```python
+LinearRing(coordinates: LineType) -> None
+```
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `coordinates` | `LineType` | — | Sequence of point tuples; the first coordinate is appended automatically if needed. |
+
+## Public Properties
+
+| Name | Type | Description |
+|---|---|---|
+| `coords` | `LineType` | Closed coordinate sequence. |
+| `centroid` | `Optional[Point]` | 2D centroid of the ring, or `None` for degenerate rings. |
+| `is_ccw` | `bool` | True when `signed_area(coords) >= 0`. |
+| `bounds` | `tuple[float, float, float, float] \| tuple[()]` | XY extent inherited from `LineString`. |
+| `wkt` | `str` | WKT representation using `LINEARRING`. |
+
+## Internal Behavior
+
+`LinearRing.__init__` first delegates to `LineString`, then appends the first point again if the line is not already closed. The `centroid` property uses `centroid()` and `signed_area()` from `pygeoif/functions.py`; it only works for 2D data and raises `DimensionError` for 3D rings.
+
+## Examples
+
+Basic usage:
+
+```python
+from pygeoif import LinearRing
+
+ring = LinearRing([(0, 0), (2, 0), (2, 1), (0, 1)])
+print(ring.coords)
+print(ring.is_ccw)
+```
+
+Centroid calculation:
+
+```python
+from pygeoif import LinearRing
+
+ring = LinearRing([(0, 0), (4, 0), (4, 2), (0, 2)])
+center = ring.centroid
+
+print(center)
+print(center.__geo_interface__)
+```
+
+## Notes
+
+- Rings self-close automatically, so you can omit the final repeated point in many cases.
+- `LinearRing` does not validate self-intersection; invalid rings can still be constructed.
+- `centroid` works only for 2D rings because the implementation is explicitly XY-only.
+
+## When To Use It
+
+Use `LinearRing` directly when you care about winding, centroid calculation, or reusable ring objects. In many applications you will meet it indirectly through `Polygon.exterior` and `Polygon.interiors`, but constructing rings yourself can still be useful when you normalize polygon input before building the polygon. Because the class inherits most behavior from `LineString`, it stays lightweight while still giving you ring-specific semantics.
+
+## Related API
+
+- [Polygon](/docs/api-reference/polygon)
+- [Functions](/docs/api-reference/functions)
+- [Factories](/docs/api-reference/factories)

--- a/docs/codedocs/api-reference/linestring.md
+++ b/docs/codedocs/api-reference/linestring.md
@@ -1,0 +1,79 @@
+---
+title: "LineString"
+description: "Reference for pygeoif.LineString, the immutable ordered sequence of points."
+---
+
+`LineString` represents a one-dimensional geometry made from an ordered sequence of points. It is implemented in `pygeoif/geometry.py` and exported at the package root as `pygeoif.LineString`.
+
+## Signature
+
+```python
+LineString(coordinates: LineType) -> None
+```
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `coordinates` | `LineType` | — | Sequence of 2D or 3D point tuples. |
+
+## Public Properties And Methods
+
+### Properties
+
+| Name | Type | Description |
+|---|---|---|
+| `geoms` | `tuple[Point, ...]` | Underlying point objects created from the coordinate sequence. |
+| `coords` | `LineType` | Deduplicated coordinate tuples in the same order. |
+| `is_empty` | `bool` | True when no valid points remain after normalization. |
+| `has_z` | `Optional[bool]` | Z-presence based on the first point, or `None` when empty. |
+| `bounds` | `tuple[float, float, float, float] \| tuple[()]` | XY extent of all points. |
+| `convex_hull` | `Point \| LineString \| Polygon \| None` | Hull of the line's XY projection. |
+| `wkt` | `str` | WKT representation such as `LINESTRING (0 0, 1 1)`. |
+| `__geo_interface__` | `GeoInterface` | GeoJSON-like mapping for the line. |
+
+### Class Methods
+
+```python
+LineString.from_coordinates(coordinates: LineType) -> LineString
+LineString.from_points(*args: Point) -> LineString
+```
+
+## Behavior
+
+Construction flows through the internal `_set_geoms()` helper in `pygeoif/geometry.py`. That helper removes consecutive duplicate coordinates with `dedupe()` from `pygeoif/functions.py`, creates `Point` objects, discards empty points, and raises `DimensionError` if dimensions are mixed inside the same line.
+
+## Examples
+
+Basic usage:
+
+```python
+from pygeoif import LineString
+
+line = LineString([(0, 0), (1, 1), (2, 1)])
+print(line.coords)
+print(line.bounds)
+print(line.wkt)
+```
+
+Building from `Point` objects:
+
+```python
+from pygeoif import LineString, Point
+
+line = LineString.from_points(Point(0, 0), Point(1, 1), Point(2, 1))
+print(tuple(p.wkt for p in line.geoms))
+print(line.__geo_interface__)
+```
+
+## Notes
+
+- Consecutive duplicate coordinates are removed during construction, but non-adjacent duplicates remain.
+- Mixed 2D and 3D coordinates raise `pygeoif.exceptions.DimensionError`.
+- `convex_hull` may return a `Point` or `Polygon` depending on the line geometry.
+
+## Related API
+
+- [LinearRing](/docs/api-reference/linearring)
+- [MultiLineString](/docs/api-reference/multilinestring)
+- [Functions](/docs/api-reference/functions)

--- a/docs/codedocs/api-reference/multilinestring.md
+++ b/docs/codedocs/api-reference/multilinestring.md
@@ -1,0 +1,75 @@
+---
+title: "MultiLineString"
+description: "Reference for pygeoif.MultiLineString, the immutable collection of line strings."
+---
+
+`MultiLineString` stores many `LineString` objects and is defined in `pygeoif/geometry.py`. Import it with `from pygeoif import MultiLineString`.
+
+## Signature
+
+```python
+MultiLineString(lines: Sequence[LineType], unique: bool = False) -> None
+```
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `lines` | `Sequence[LineType]` | — | Coordinate sequences used to build the member line strings. |
+| `unique` | `bool` | `False` | Deduplicates lines using a set conversion. Ordering is not preserved. |
+
+## Public API
+
+| Name | Type | Description |
+|---|---|---|
+| `geoms` | `Iterator[LineString]` | Yields non-empty member lines. |
+| `has_z` | `Optional[bool]` | True if any member line has Z values. |
+| `is_empty` | `bool` | True when all members are empty. |
+| `bounds` | `tuple[float, float, float, float] \| tuple[()]` | Aggregate XY extent. |
+| `wkt` | `str` | WKT representation such as `MULTILINESTRING ((...),(...))`. |
+| `__geo_interface__` | `GeoInterface` | GeoJSON-like mapping for the collection. |
+| `__len__()` | `int` | Number of stored member lines. |
+
+### Class Methods
+
+```python
+MultiLineString.from_linestrings(*args: LineString, unique: bool = False) -> MultiLineString
+```
+
+## Examples
+
+Basic usage:
+
+```python
+from pygeoif import MultiLineString
+
+lines = MultiLineString([[(0, 0), (1, 1)], [(2, 2), (3, 2)]])
+print(len(lines))
+print(lines.bounds)
+```
+
+Building from `LineString` instances:
+
+```python
+from pygeoif import LineString, MultiLineString
+
+multi = MultiLineString.from_linestrings(
+    LineString([(0, 0), (1, 1)]),
+    LineString([(1, 1), (2, 1)]),
+)
+
+print([line.wkt for line in multi.geoms])
+print(multi.__geo_interface__)
+```
+
+## Notes
+
+- Deduplication with `unique=True` converts each line to a tuple and may reorder the result.
+- The class aggregates hull input by yielding points from each member line.
+- The public surface is intentionally small because `_MultiGeometry` provides most collection behavior.
+
+## Related API
+
+- [LineString](/docs/api-reference/linestring)
+- [GeometryCollection](/docs/api-reference/geometrycollection)
+- [Functions](/docs/api-reference/functions)

--- a/docs/codedocs/api-reference/multipoint.md
+++ b/docs/codedocs/api-reference/multipoint.md
@@ -1,0 +1,73 @@
+---
+title: "MultiPoint"
+description: "Reference for pygeoif.MultiPoint, the immutable collection of point geometries."
+---
+
+`MultiPoint` is a homogeneous collection of `Point` objects defined in `pygeoif/geometry.py` and exported at the package root as `pygeoif.MultiPoint`.
+
+## Signature
+
+```python
+MultiPoint(points: Sequence[PointType], unique: bool = False) -> None
+```
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `points` | `Sequence[PointType]` | — | Point coordinate tuples used to build the collection. |
+| `unique` | `bool` | `False` | Removes duplicates by converting the input to a set. Order is not preserved. |
+
+## Public API
+
+### Properties And Methods
+
+| Name | Type | Description |
+|---|---|---|
+| `geoms` | `Iterator[Point]` | Yields non-empty points in the collection. |
+| `has_z` | `Optional[bool]` | True if any stored point has Z values. |
+| `is_empty` | `bool` | True when all stored members are empty. |
+| `bounds` | `tuple[float, float, float, float] \| tuple[()]` | Aggregate XY extent. |
+| `wkt` | `str` | WKT representation such as `MULTIPOINT ((0 0), (1 1))`. |
+| `__geo_interface__` | `GeoInterface` | GeoJSON-like mapping for the collection. |
+| `__len__()` | `int` | Number of stored point objects. |
+
+### Class Methods
+
+```python
+MultiPoint.from_points(*args: Point, unique: bool = False) -> MultiPoint
+```
+
+## Examples
+
+Basic usage:
+
+```python
+from pygeoif import MultiPoint
+
+points = MultiPoint([(0, 0), (1, 1), (2, 2)])
+print(len(points))
+print([p.coords for p in points.geoms])
+```
+
+Deduplicated creation:
+
+```python
+from pygeoif import MultiPoint, Point
+
+points = MultiPoint.from_points(Point(0, 0), Point(0, 0), Point(1, 1) unique=True)
+print(len(points))
+print(points.__geo_interface__)
+```
+
+## Notes
+
+- `unique=True` removes duplicates but does not preserve input ordering because it uses a set.
+- The collection inherits bounds and hull behavior from `_MultiGeometry`.
+- `MultiPoint` does not expose a flat `.coords` property; iterate `geoms` instead.
+
+## Related API
+
+- [Point](/docs/api-reference/point)
+- [GeometryCollection](/docs/api-reference/geometrycollection)
+- [Functions](/docs/api-reference/functions)

--- a/docs/codedocs/api-reference/multipolygon.md
+++ b/docs/codedocs/api-reference/multipolygon.md
@@ -1,0 +1,80 @@
+---
+title: "MultiPolygon"
+description: "Reference for pygeoif.MultiPolygon, the immutable collection of polygon geometries."
+---
+
+`MultiPolygon` represents a homogeneous collection of polygons. It is implemented in `pygeoif/geometry.py` and exported as `pygeoif.MultiPolygon`.
+
+## Signature
+
+```python
+MultiPolygon(polygons: Sequence[PolygonType], unique: bool = False) -> None
+```
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `polygons` | `Sequence[PolygonType]` | — | Polygon coordinate tuples in `(shell, holes?)` form. |
+| `unique` | `bool` | `False` | Deduplicates polygons using a set conversion, losing order. |
+
+## Public API
+
+| Name | Type | Description |
+|---|---|---|
+| `geoms` | `Iterator[Polygon]` | Yields non-empty polygons. |
+| `has_z` | `Optional[bool]` | True if any member polygon has Z values. |
+| `is_empty` | `bool` | True when all members are empty. |
+| `bounds` | `tuple[float, float, float, float] \| tuple[()]` | Aggregate XY extent. |
+| `wkt` | `str` | WKT representation such as `MULTIPOLYGON (((...)), ((...)))`. |
+| `__geo_interface__` | `GeoInterface` | GeoJSON-like mapping with one polygon coordinate sequence per member. |
+| `__len__()` | `int` | Number of stored polygons. |
+
+### Class Methods
+
+```python
+MultiPolygon.from_polygons(*args: Polygon, unique: bool = False) -> MultiPolygon
+```
+
+## Examples
+
+Basic usage:
+
+```python
+from pygeoif import MultiPolygon
+
+multi = MultiPolygon(
+    [
+        (((0, 0), (2, 0), (2, 2), (0, 2), (0, 0)),),
+        (((10, 10), (12, 10), (12, 12), (10, 12), (10, 10)),),
+    ]
+)
+
+print(len(multi))
+print(multi.bounds)
+```
+
+Building from polygons:
+
+```python
+from pygeoif import MultiPolygon, Polygon
+
+first = Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)])
+second = Polygon([(3, 3), (4, 3), (4, 4), (3, 4), (3, 3)])
+multi = MultiPolygon.from_polygons(first, second)
+
+print([polygon.wkt for polygon in multi.geoms])
+print(multi.__geo_interface__)
+```
+
+## Notes
+
+- The class does not validate overlap between member polygons even though overlapping members are semantically invalid in many GIS contexts.
+- `unique=True` uses set semantics and should only be used when ordering is irrelevant.
+- Hull calculations flatten all polygon hull points from member geometries.
+
+## Related API
+
+- [Polygon](/docs/api-reference/polygon)
+- [GeometryCollection](/docs/api-reference/geometrycollection)
+- [Factories](/docs/api-reference/factories)

--- a/docs/codedocs/api-reference/point.md
+++ b/docs/codedocs/api-reference/point.md
@@ -1,0 +1,87 @@
+---
+title: "Point"
+description: "Reference for pygeoif.Point, the immutable zero-dimensional geometry type."
+---
+
+`Point` represents a single 2D or 3D coordinate and is defined in `pygeoif/geometry.py`. Import it from the package root with `from pygeoif import Point` or from the implementation module with `from pygeoif.geometry import Point`.
+
+## Signature
+
+```python
+Point(x: float, y: float, z: Optional[float] = None) -> None
+```
+
+Source: `pygeoif/geometry.py`
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `x` | `float` | — | X or longitude coordinate. |
+| `y` | `float` | — | Y or latitude coordinate. |
+| `z` | `Optional[float]` | `None` | Optional elevation or third dimension. |
+
+## Public Properties And Methods
+
+### Properties
+
+| Name | Type | Description |
+|---|---|---|
+| `x` | `float` | Returns the first coordinate. |
+| `y` | `float` | Returns the second coordinate. |
+| `z` | `Optional[float]` | Returns the third coordinate or raises `DimensionError` if absent. |
+| `coords` | `tuple[PointType] \| tuple[()]` | Returns `((x, y),)` or `((x, y, z),)` for non-empty points. |
+| `is_empty` | `bool` | True when any stored coordinate is `None` or `NaN`. |
+| `has_z` | `bool` | True when the point stores three coordinates. |
+| `bounds` | `tuple[float, float, float, float] \| tuple[()]` | `(minx, miny, maxx, maxy)` for non-empty points. |
+| `convex_hull` | `Point \| LineString \| Polygon \| None` | Returns the point itself for non-empty points. |
+| `wkt` | `str` | WKT representation such as `POINT (1 2)` or `POINT Z (1 2 3)`. |
+| `__geo_interface__` | `GeoInterface` | GeoJSON-like mapping with `type`, `bbox`, and `coordinates`. |
+
+### Class Methods
+
+```python
+Point.from_coordinates(coordinates: Sequence[PointType]) -> Point
+```
+
+Build a point from the first coordinate tuple in a coordinate sequence.
+
+## Return Value
+
+The constructor returns an immutable `Point` instance. Equality is value-based and uses coordinate comparison rather than object identity.
+
+## Examples
+
+Basic usage:
+
+```python
+from pygeoif import Point
+
+point = Point(1.5, -3.0)
+print(point.x, point.y)
+print(point.bounds)
+print(point.wkt)
+```
+
+Three-dimensional usage:
+
+```python
+from pygeoif import Point
+
+point = Point(10, 20, 5)
+print(point.has_z)
+print(point.coords)
+print(point.__geo_interface__)
+```
+
+## Notes
+
+- Empty points are possible if a coordinate is `None` or `NaN`; in that case `bool(point)` is `False`.
+- Accessing `.z` on a 2D point raises `pygeoif.exceptions.DimensionError`.
+- `Point.__geo_interface__` raises `AttributeError("Empty Geometry")` for empty points, matching the base geometry behavior in `pygeoif/geometry.py`.
+
+## Related API
+
+- [LineString](/docs/api-reference/linestring)
+- [Functions](/docs/api-reference/functions)
+- [Factories](/docs/api-reference/factories)

--- a/docs/codedocs/api-reference/polygon.md
+++ b/docs/codedocs/api-reference/polygon.md
@@ -1,0 +1,79 @@
+---
+title: "Polygon"
+description: "Reference for pygeoif.Polygon, including shells, holes, and polygon-specific constructors."
+---
+
+`Polygon` models an exterior ring plus zero or more interior rings. It is defined in `pygeoif/geometry.py` and exported as `pygeoif.Polygon`.
+
+## Signature
+
+```python
+Polygon(shell: LineType, holes: Optional[Sequence[LineType]] = None) -> None
+```
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `shell` | `LineType` | — | Exterior ring coordinates. |
+| `holes` | `Optional[Sequence[LineType]]` | `None` | Optional interior ring coordinate sequences. |
+
+## Public Properties And Methods
+
+### Properties
+
+| Name | Type | Description |
+|---|---|---|
+| `exterior` | `LinearRing` | Exterior ring of the polygon. |
+| `interiors` | `Iterator[LinearRing]` | Interior rings yielded lazily. |
+| `coords` | `PolygonType` | Exterior ring, then optional interior ring tuple. |
+| `is_empty` | `bool` | True when the exterior ring is empty. |
+| `has_z` | `Optional[bool]` | Z-presence based on the exterior ring. |
+| `bounds` | `tuple[float, float, float, float] \| tuple[()]` | XY extent of the exterior ring. |
+| `convex_hull` | `Point \| LineString \| Polygon \| None` | Hull of the polygon's exterior coordinates projected to XY. |
+| `wkt` | `str` | WKT representation with optional interior rings. |
+| `__geo_interface__` | `GeoInterface` | Polygon mapping with shell then holes. |
+
+### Class Methods
+
+```python
+Polygon.from_coordinates(coordinates: PolygonType) -> Polygon
+Polygon.from_linear_rings(shell: LinearRing, *args: LinearRing) -> Polygon
+```
+
+## Examples
+
+Basic usage:
+
+```python
+from pygeoif import Polygon
+
+polygon = Polygon([(0, 0), (4, 0), (4, 3), (0, 3), (0, 0)])
+print(polygon.exterior.coords)
+print(polygon.bounds)
+```
+
+Polygon with holes:
+
+```python
+from pygeoif import LinearRing, Polygon
+
+shell = LinearRing([(0, 0), (5, 0), (5, 5), (0, 5)])
+hole = LinearRing([(1, 1), (2, 1), (2, 2), (1, 2)])
+polygon = Polygon.from_linear_rings(shell, hole)
+
+print([ring.coords for ring in polygon.interiors])
+print(polygon.wkt)
+```
+
+## Notes
+
+- `coords` is intentionally public even though Shapely does not expose polygon coordinates in the same way.
+- Empty polygons can be constructed indirectly through `_from_dict()` when the incoming coordinates are empty.
+- The class does not validate topology such as ring overlap or self-intersection.
+
+## Related API
+
+- [LinearRing](/docs/api-reference/linearring)
+- [MultiPolygon](/docs/api-reference/multipolygon)
+- [Factories](/docs/api-reference/factories)

--- a/docs/codedocs/api-reference/types-and-protocols.md
+++ b/docs/codedocs/api-reference/types-and-protocols.md
@@ -1,0 +1,96 @@
+---
+title: "Types And Protocols"
+description: "Reference for the public type aliases, TypedDict definitions, and protocols exported by pygeoif.types."
+---
+
+`pygeoif.types` exports the shared type vocabulary used by the rest of the package. These are Python typing constructs rather than TypeScript types, but they are still part of the public API and useful when you annotate your own wrappers or protocol adapters.
+
+Import path: `from pygeoif.types import ...`
+
+## Type Aliases
+
+```python
+Point2D = tuple[float, float]
+Point3D = tuple[float, float, float]
+PointType = Union[Point2D, Point3D]
+LineType = Union[Sequence[Point2D], Sequence[Point3D]]
+Interiors = Optional[Sequence[LineType]]
+PolygonType = Union[
+    Union[tuple[Sequence[Point2D], Sequence[Sequence[Point2D]]], tuple[Sequence[Point2D]]],
+    Union[tuple[Sequence[Point3D], Sequence[Sequence[Point3D]]], tuple[Sequence[Point3D]]],
+]
+MultiGeometryType = Sequence[Union[PointType, LineType, PolygonType]]
+Bounds = tuple[float, float, float, float]
+CoordinatesType = Union[PointType, LineType, Sequence[LineType]]
+MultiCoordinatesType = Sequence[CoordinatesType]
+```
+
+## TypedDict Definitions
+
+```python
+class GeoInterface(TypedDict):
+    type: GeomType
+    coordinates: Union[CoordinatesType, MultiCoordinatesType]
+    bbox: NotRequired[Bounds]
+
+class GeoCollectionInterface(TypedDict):
+    type: Literal["GeometryCollection"]
+    geometries: Sequence[Union[GeoInterface, "GeoCollectionInterface"]]
+    bbox: NotRequired[Bounds]
+
+class GeoFeatureInterface(TypedDict):
+    type: Literal["Feature"]
+    bbox: NotRequired[Bounds]
+    properties: NotRequired[dict[str, Any]]
+    id: NotRequired[Union[str, int]]
+    geometry: GeoInterface
+
+class GeoFeatureCollectionInterface(TypedDict):
+    type: Literal["FeatureCollection"]
+    features: Sequence[GeoFeatureInterface]
+    bbox: NotRequired[Bounds]
+    id: NotRequired[Union[str, int]]
+```
+
+## Protocols
+
+```python
+class GeoType(Protocol):
+    @property
+    def __geo_interface__(self) -> GeoInterface: ...
+
+class GeoCollectionType(Protocol):
+    @property
+    def __geo_interface__(self) -> GeoCollectionInterface: ...
+```
+
+## When To Use Them
+
+- Use `PointType`, `LineType`, and `PolygonType` when you accept raw coordinate tuples in your own helpers.
+- Use `GeoInterface` and `GeoCollectionInterface` when you want to type GeoJSON-like dictionaries exchanged with `shape()` or `mapping()`.
+- Use `GeoType` and `GeoCollectionType` when you accept foreign objects that implement `__geo_interface__` without depending on their concrete class.
+
+## Example
+
+```python
+from pygeoif import shape
+from pygeoif.types import GeoInterface
+
+def build_geometry(payload: GeoInterface):
+    return shape(payload)
+
+point = build_geometry({"type": "Point", "coordinates": (1, 2)})
+print(point.wkt)
+```
+
+## Notes
+
+- The `GeomType` literal covers only the non-collection geometry names implemented in `pygeoif`.
+- Feature-related TypedDicts live here even though feature classes themselves live in `pygeoif/feature.py`.
+- These type exports are especially useful when integrating with static type checking tools such as mypy or pyright, both of which are configured in `pyproject.toml`.
+
+## Related API
+
+- [Factories](/docs/api-reference/factories)
+- [Functions](/docs/api-reference/functions)
+- [Feature](/docs/api-reference/feature)

--- a/docs/codedocs/architecture.md
+++ b/docs/codedocs/architecture.md
@@ -1,0 +1,84 @@
+---
+title: "Architecture"
+description: "Understand how pygeoif organizes geometry classes, conversion helpers, low-level algorithms, and feature wrappers."
+---
+
+`pygeoif` keeps its design intentionally small. The package root in `pygeoif/__init__.py` re-exports the geometry classes from `pygeoif/geometry.py`, feature wrappers from `pygeoif/feature.py`, and the main conversion helpers from `pygeoif/factories.py`. Those layers sit on top of shared types from `pygeoif/types.py`, algorithms from `pygeoif/functions.py`, and a few custom exceptions from `pygeoif/exceptions.py`.
+
+```mermaid
+graph TD
+  A[pygeoif/__init__.py] --> B[geometry.py]
+  A --> C[feature.py]
+  A --> D[factories.py]
+  D --> B
+  D --> E[functions.py]
+  D --> F[exceptions.py]
+  B --> E
+  B --> G[types.py]
+  C --> B
+  C --> E
+  C --> G
+  H[hypothesis/strategies.py] --> B
+  H --> G
+```
+
+## Module Responsibilities
+
+- `pygeoif/geometry.py` defines the immutable value objects: `Point`, `LineString`, `LinearRing`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection`.
+- `pygeoif/functions.py` implements shared computational helpers such as `signed_area()`, `centroid()`, `convex_hull()`, coordinate comparison, and recursive coordinate movement.
+- `pygeoif/factories.py` converts between external representations and geometry objects. That includes `shape()`, `mapping()`, `from_wkt()`, `force_2d()`, `force_3d()`, `box()`, and `orient()`.
+- `pygeoif/feature.py` wraps geometries in GeoJSON-style `Feature` and `FeatureCollection` containers.
+- `pygeoif/types.py` centralizes public type aliases and `TypedDict`/`Protocol` definitions used throughout the package.
+- `pygeoif/hypothesis/strategies.py` builds optional Hypothesis strategies on top of the geometry constructors.
+
+## Data Flow
+
+The most common lifecycle starts with external coordinates, a GeoJSON-like mapping, or a WKT string. `shape()` and `from_wkt()` parse those inputs in `pygeoif/factories.py`, instantiate the correct class from `pygeoif/geometry.py`, and return an immutable object. Once a geometry exists, its `.wkt`, `.bounds`, `.convex_hull`, and `.__geo_interface__` properties depend on shared algorithms from `pygeoif/functions.py`. Feature wrappers then embed those objects inside `Feature` and `FeatureCollection` containers without changing the underlying geometry.
+
+```mermaid
+flowchart TD
+  A[GeoJSON-like dict or __geo_interface__ object] --> B[shape]
+  C[WKT string] --> D[from_wkt]
+  B --> E[Geometry instance]
+  D --> E
+  E --> F[__geo_interface__]
+  E --> G[wkt]
+  E --> H[bounds and convex_hull]
+  E --> I[Feature or FeatureCollection]
+```
+
+## Key Design Decisions
+
+### Immutable geometry objects
+
+The internal base class `_Geometry` in `pygeoif/geometry.py` overrides `__setattr__` and `__delattr__` to reject mutation after construction. The concrete classes only assign state through `object.__setattr__` during initialization. That decision makes geometry instances reliable value objects: equality, hashing behavior from the stored tuples, and repeated serialization stay stable once constructed.
+
+### Copying external geometry instead of aliasing it
+
+`shape()` in `pygeoif/factories.py` converts mappings into new geometry objects instead of returning a wrapper over the original structure. The docstring explicitly says coordinates are copied. That avoids a common interoperability bug where a library stores someone else’s mutable dictionary and later observes unexpected changes.
+
+### Shared algorithms, not duplicated logic
+
+`pygeoif/functions.py` contains the reusable math and recursive traversal logic. `geometry.py` delegates to `convex_hull()`, `centroid()`, `signed_area()`, `compare_coordinates()`, and `compare_geo_interface()` instead of reimplementing those calculations per class. That keeps behavior consistent between single geometries, multi-geometries, factories, and feature comparisons.
+
+### Dimension handling through coercion helpers
+
+The project deliberately separates dimensional coercion from normal construction. Constructors enforce internally consistent point dimensions, while `force_2d()` and `force_3d()` in `pygeoif/factories.py` rebuild geometries by moving their `__geo_interface__` with `move_geo_interface()`. That means the rules for dropping or adding Z values are centralized, predictable, and reusable across every geometry type including `GeometryCollection`.
+
+## Configuration Surface
+
+There are no environment variables, global registries, or mutable runtime settings. Configuration is limited to constructor and helper parameters:
+
+| Surface | Parameters | Purpose |
+|---|---|---|
+| Geometry constructors | Coordinates and optional `holes` or `unique` flags | Build immutable geometry values |
+| Factory helpers | `ccw`, `z`, bounding box coordinates, or WKT string input | Convert or normalize shapes |
+| Hypothesis strategies | `srs`, `has_z`, `max_points`, `max_interiors`, and related bounds | Generate constrained random geometries |
+
+That narrow configuration surface is a deliberate architectural choice. You do not initialize a global client or session object. You construct values, derive alternate views of those values, and pass them into surrounding code.
+
+## How The Pieces Fit Together
+
+If you create a `Polygon`, `geometry.py` stores its exterior and interior rings as `LinearRing` instances. If you call `orient()`, `factories.py` reads the exterior and interior coordinates, uses `signed_area()` from `functions.py` to decide whether a reversal is needed, and returns a new `Polygon`. If you then wrap that polygon in a `Feature`, `feature.py` simply assembles the geometry’s existing `__geo_interface__` and bounds into a GeoJSON Feature mapping.
+
+That pattern shows up everywhere in `pygeoif`: small immutable objects, thin conversion helpers, and algorithm utilities shared across the package. The result is a library that stays easy to reason about even when you use several modules together.

--- a/docs/codedocs/factories-and-conversion.md
+++ b/docs/codedocs/factories-and-conversion.md
@@ -1,0 +1,71 @@
+---
+title: "Factories And Conversion"
+description: "See how pygeoif turns mappings and WKT into geometry objects, normalizes dimensionality, and fixes polygon orientation."
+---
+
+The conversion layer in `pygeoif/factories.py` is where external representations become immutable geometry instances. This concept matters because most real applications do not start with `Point(...)` or `Polygon(...)` literals. They start with GeoJSON-like dictionaries from APIs, WKT from databases, or geometry objects from another library. `pygeoif` keeps that boundary explicit through a handful of focused helper functions rather than through hidden magic in every class.
+
+The key public helpers are `shape()`, `mapping()`, `from_wkt()`, `force_2d()`, `force_3d()`, `orient()`, and `box()`. These functions relate directly to the geometry model and `__geo_interface__`: `shape()` consumes compatible protocol objects, `mapping()` exposes them, `from_wkt()` and `.wkt` bridge text representations, and the dimensionality/orientation helpers rebuild new normalized shapes.
+
+```mermaid
+flowchart TD
+  A[Input mapping or __geo_interface__] --> B[shape]
+  C[WKT string] --> D[from_wkt]
+  E[Geometry] --> F[mapping]
+  E --> G[force_2d or force_3d]
+  E --> H[orient]
+  B --> I[New geometry]
+  D --> I
+  G --> J[Normalized geometry]
+  H --> K[Reoriented polygon]
+```
+
+## How It Works Internally
+
+`shape()` first normalizes the input into a mapping. If the input is already a `dict`, it uses it directly; otherwise it calls `mapping()` to read `.__geo_interface__`. It then dispatches by `type` using a small `type_map` of geometry classes. For non-collection types it calls the class-level `_from_dict()` method implemented in `pygeoif/geometry.py`. For geometry collections it recursively calls `shape()` on each member and then constructs a new `GeometryCollection`.
+
+`from_wkt()` is deliberately compact. It uppercases and trims the input, validates it with a regular expression, extracts the geometry type, then routes to a parser dedicated to each supported WKT form. Nested structures such as `GEOMETRYCOLLECTION` use `split_wkt_components()` to split only on commas at the outermost parenthesis level. That avoids the classic bug where you accidentally split inside a polygon ring.
+
+`force_2d()` and `force_3d()` do not special-case every class. Instead, they read the object’s protocol mapping, pass it through `move_geo_interface()` in `pygeoif/functions.py`, and call `shape()` again. This is a strong design choice: the normalization logic is recursive, so the same rule works for points, polygons, and nested geometry collections.
+
+## Basic Usage
+
+```python
+from pygeoif import from_wkt, force_3d, mapping, shape
+
+road = from_wkt("LINESTRING (0 0, 2 1, 3 1)")
+road_3d = force_3d(road z=25)
+copy = shape(mapping(road_3d))
+
+print(road_3d.wkt)
+print(copy == road_3d)
+```
+
+## Advanced Usage
+
+Polygon orientation matters when you integrate with systems that expect CCW shells and CW holes.
+
+```python
+from pygeoif import Polygon, orient
+
+polygon = Polygon(
+    shell=[(0, 0), (0, 4), (4, 4), (4, 0), (0, 0)],
+    holes=[[(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)]],
+)
+
+normalized = orient(polygon ccw=True)
+
+print(normalized.exterior.is_ccw)
+print([ring.is_ccw for ring in normalized.interiors])
+```
+
+<Callout type="warn">`from_wkt()` supports the geometry types hard-coded in `type_map` and raises `WKTParserError` for unsupported or malformed input. It also normalizes the input to uppercase before parsing, so it is a parser for WKT geometry values, not for preserving original text formatting. `force_2d()` and `force_3d()` always rebuild a new object, so keep the returned geometry instead of expecting in-place mutation.</Callout>
+
+<Accordions>
+<Accordion title="Why dimensional coercion is implemented through protocol movement">
+`force_2d()` and `force_3d()` could have been implemented as a long set of `isinstance()` branches, one for every geometry class. Instead, `pygeoif` translates the geometry into its protocol form, recursively adjusts coordinates with `move_geo_interface()`, and reconstructs the result with `shape()`. That keeps the code smaller and guarantees identical rules for single geometries and collections. The cost is an extra conversion step, but the payoff is architectural consistency and less duplicated branching logic.
+</Accordion>
+<Accordion title="Why WKT parsing stays lightweight instead of becoming a full SQL parser">
+The WKT parser in `pygeoif/factories.py` is intentionally focused on geometry text, not on parsing every database-specific wrapper or metadata extension. It accepts a leading `SRID=...;` segment but otherwise looks only for the supported geometry forms and their coordinates. That makes the parser easy to audit and keeps dependencies at zero, which fits the package's pure-Python design. The trade-off is that exotic vendor-specific WKT variations may need preprocessing before you pass them into `from_wkt()`.
+</Accordion>
+</Accordions>

--- a/docs/codedocs/features-and-collections.md
+++ b/docs/codedocs/features-and-collections.md
@@ -1,0 +1,65 @@
+---
+title: "Features And Collections"
+description: "Learn how pygeoif wraps geometries in GeoJSON-style Feature and FeatureCollection containers."
+---
+
+The geometry classes model spatial shapes. `Feature` and `FeatureCollection`, defined in `pygeoif/feature.py`, model the next layer up: a geometry plus application data. This concept exists because spatial applications almost never ship raw polygons or points alone. They attach identifiers, names, categories, or arbitrary metadata to those shapes and often group them into collections for transport and storage.
+
+In `pygeoif`, `Feature` is a thin wrapper around a geometry plus a `properties` dictionary and optional `feature_id`. `FeatureCollection` groups many `Feature` objects and computes an aggregate bounding box from the geometries it contains. These objects relate to the `__geo_interface__` concept directly because both serialize into GeoJSON-like `Feature` and `FeatureCollection` mappings.
+
+## How It Works Internally
+
+`Feature.__geo_interface__` assembles a mapping with `type: "Feature"`, the geometry’s `bbox`, the geometry’s own `__geo_interface__`, and the properties dictionary. If `feature_id` is present it adds an `id` field. Equality delegates to `feature_geo_interface_equals()`, which compares the `id`, `type`, properties, nested geometry type, and nested coordinates using `compare_coordinates()` from `pygeoif/functions.py`.
+
+`FeatureCollection` stores features as an immutable tuple, exposes iteration, and computes `.bounds` by zipping the bounds of every member geometry. Its equality path first checks that the other object looks like a compatible collection and has the same number of features, then compares the protocol mapping of each feature in order. That order sensitivity matches how features are stored and serialized.
+
+## Basic Usage
+
+```python
+from pygeoif import Feature, FeatureCollection, Point
+
+city_hall = Feature(
+    Point(-73.9857, 40.7484),
+    properties={"name": "City Hall", "kind": "landmark"},
+    feature_id="city-hall",
+)
+
+places = FeatureCollection([city_hall])
+
+print(city_hall.__geo_interface__["type"])
+print(places.bounds)
+```
+
+## Advanced Usage
+
+You can mix geometry types inside one `FeatureCollection`, which is often useful when building response payloads for map overlays.
+
+```python
+from pygeoif import Feature, FeatureCollection, LineString, Point, Polygon
+
+features = FeatureCollection(
+    [
+        Feature(Point(0, 0), {"role": "start"}, feature_id=1),
+        Feature(LineString([(0, 0), (2, 1)]), {"role": "route"}, feature_id=2),
+        Feature(
+            Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)]),
+            {"role": "zone"},
+            feature_id=3,
+        ),
+    ]
+)
+
+print(len(features))
+print(features.__geo_interface__["bbox"])
+```
+
+<Callout type="warn">`Feature.properties` returns the stored dictionary directly, so the feature wrapper itself is not an immutable value object in the same sense as the geometry classes. If you mutate the properties mapping after construction, later `__geo_interface__` output reflects those changes. Also note that `FeatureCollection.bounds` assumes each feature geometry has bounds, so empty geometries are a poor fit for collection-wide extent calculations.</Callout>
+
+<Accordions>
+<Accordion title="Why Feature wraps only one geometry">
+`Feature` stays close to the GeoJSON data model and always stores exactly one geometry plus metadata. That keeps serialization simple and makes it obvious how to map the object into APIs, files, and downstream libraries. If you need many geometries under one record, the intended pattern is to wrap a `GeometryCollection` in a `Feature`, not to invent a parallel container shape. The trade-off is that your domain model sometimes needs one extra object when a business entity naturally spans several shapes.
+</Accordion>
+<Accordion title="Mutable properties versus immutable geometry">
+The geometry classes are intentionally immutable, but `Feature.properties` is a normal Python dictionary. That split is pragmatic: metadata often needs to be assembled or updated as an application pipeline progresses, while geometry coordinates benefit from staying stable once normalized. The trade-off is that `Feature` equality can change over time if you mutate `properties`, because equality compares the protocol mapping including the metadata payload. If you need fully stable feature values, copy or freeze the properties mapping before constructing the feature.
+</Accordion>
+</Accordions>

--- a/docs/codedocs/geo-interface.md
+++ b/docs/codedocs/geo-interface.md
@@ -1,0 +1,69 @@
+---
+title: "Geo Interface"
+description: "Understand how pygeoif uses the __geo_interface__ protocol for interoperability with GeoJSON-like tools and libraries."
+---
+
+The `__geo_interface__` protocol is the interoperability contract at the center of `pygeoif`. Every geometry class, `Feature`, and `FeatureCollection` exposes a GeoJSON-like mapping through a `.__geo_interface__` property. The protocol exists so objects from unrelated libraries can exchange geometry data without sharing the same class hierarchy, database client, or serialization format.
+
+Inside `pygeoif`, this concept ties everything together. `mapping()` returns the raw protocol mapping from any compatible object, `shape()` turns a mapping or any `__geo_interface__` object back into a new `pygeoif` geometry, and equality helpers in `pygeoif/functions.py` compare protocol representations rather than relying on identity.
+
+```mermaid
+sequenceDiagram
+  participant External as External object or dict
+  participant Factory as shape or mapping
+  participant Geometry as pygeoif geometry
+  External->>Factory: GeoJSON-like mapping or __geo_interface__
+  Factory->>Geometry: Instantiate copied geometry
+  Geometry-->>Factory: __geo_interface__
+  Factory-->>External: Plain mapping for downstream code
+```
+
+## How It Works Internally
+
+The base implementation in `_Geometry.__geo_interface__` returns a mapping with `type`, `bbox`, and a placeholder `coordinates` field. Each concrete class fills in the actual coordinates. `Point.__geo_interface__` writes a single point tuple, `LineString.__geo_interface__` writes a tuple of coordinate tuples, and `Polygon.__geo_interface__` writes the exterior ring followed by any interior rings. `GeometryCollection` is special: its override returns `type: "GeometryCollection"` and a `geometries` sequence instead of `coordinates`.
+
+`Feature.__geo_interface__` in `pygeoif/feature.py` embeds the wrapped geometry’s protocol output and adds `properties`, `bbox`, and optional `id`. `FeatureCollection.__geo_interface__` then aggregates many features. On the reverse path, `shape()` in `pygeoif/factories.py` switches on the incoming `type` field, dispatches to the correct class `_from_dict()` constructor, and recursively rebuilds geometry collections.
+
+## Basic Usage
+
+```python
+from pygeoif import Point, mapping, shape
+
+point = Point(4, 5)
+payload = mapping(point)
+copy = shape(payload)
+
+print(payload)
+print(copy == point)
+```
+
+## Advanced Usage
+
+You can bridge custom classes into `pygeoif` as long as they expose a conforming `__geo_interface__`.
+
+```python
+from pygeoif import shape
+
+class VendorPolygon:
+    @property
+    def __geo_interface__(self):
+        return {
+            "type": "Polygon",
+            "coordinates": (((0, 0), (2, 0), (2, 1), (0, 1), (0, 0)),),
+        }
+
+polygon = shape(VendorPolygon())
+print(polygon.wkt)
+print(polygon.bounds)
+```
+
+<Callout type="warn">Empty geometries do not produce a usable `__geo_interface__`. `_Geometry.__geo_interface__` raises `AttributeError("Empty Geometry")` when `is_empty` is true, so code that serializes arbitrary inputs should check truthiness or `is_empty` first. Also remember that `shape()` only supports the geometry types implemented in `pygeoif`; unknown `type` values raise `NotImplementedError`.</Callout>
+
+<Accordions>
+<Accordion title="Why pygeoif returns tuples instead of mutable GeoJSON lists">
+The protocol is GeoJSON-like, not a literal JSON serializer. `pygeoif` returns tuples because its own object model is immutable and tuple output preserves that intent at the Python level. This means the protocol output is excellent for internal interoperability and comparison, but if you need strict JSON you may still want to convert tuples to lists before encoding. The advantage is that round-tripping through `shape()` and `mapping()` keeps data stable and hash-friendly for Python code.
+</Accordion>
+<Accordion title="Protocol compatibility versus full GeoJSON behavior">
+`pygeoif` focuses on the geometry and feature mapping contract rather than implementing every concern of a full GeoJSON toolkit. There is no CRS management layer, streaming parser, or validation engine attached to `__geo_interface__`. That keeps the package lightweight and easy to embed, but it also means malformed or semantically invalid geometry can still exist as long as it fits the expected structure. Use `pygeoif` as a geometry value layer, not as a full GeoJSON governance framework.
+</Accordion>
+</Accordions>

--- a/docs/codedocs/geometry-model.md
+++ b/docs/codedocs/geometry-model.md
@@ -1,0 +1,72 @@
+---
+title: "Geometry Model"
+description: "Learn how pygeoif represents geometry objects, enforces immutability, and exposes shared geometry behavior."
+---
+
+The core abstraction in `pygeoif` is the immutable geometry value object defined in `pygeoif/geometry.py`. Every concrete geometry inherits from the internal `_Geometry` base class, which provides shared behavior such as `.bounds`, `.convex_hull`, `.wkt`, `.__geo_interface__`, truthiness, and equality. This abstraction exists so all geometry types can be created, compared, serialized, and transformed with the same mental model even though their coordinate layouts differ.
+
+`Point`, `LineString`, `LinearRing`, and `Polygon` represent single geometries. `MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection` wrap many geometries while still behaving like immutable values. Related concepts build directly on top of this model: factories create geometry objects, feature wrappers embed them, and the Hypothesis strategies generate them.
+
+```mermaid
+graph TD
+  A[_Geometry] --> B[Point]
+  A --> C[LineString]
+  C --> D[LinearRing]
+  A --> E[Polygon]
+  A --> F[_MultiGeometry]
+  F --> G[MultiPoint]
+  F --> H[MultiLineString]
+  F --> I[MultiPolygon]
+  F --> J[GeometryCollection]
+```
+
+## How It Works Internally
+
+Immutability is enforced in `_Geometry` by overriding `__setattr__` and `__delattr__` to always raise `AttributeError`. Concrete classes bypass that restriction only inside their constructors via `object.__setattr__`. For example, `Point.__init__` stores either `(x, y)` or `(x, y, z)`, while `LineString.__init__` delegates coordinate normalization to `_set_geoms()`, which deduplicates consecutive coordinates and rejects mixed dimensionality with `DimensionError`.
+
+The shared `.convex_hull` property in `_Geometry` is also worth understanding. It calls `self._prepare_hull()` on the concrete geometry, feeds those 2D points into `convex_hull()` from `pygeoif/functions.py`, and then collapses the result back into `Point`, `LineString`, or `Polygon` depending on how many hull vertices remain. That is why a degenerate polygon can return a line or point instead of always returning a polygon.
+
+Multi-geometries use `_MultiGeometry` to share iteration, emptiness checks, bounds aggregation, and Z-dimension detection. The design keeps each concrete class small: `MultiPoint`, `MultiLineString`, and `MultiPolygon` mainly define construction, WKT formatting, and `__geo_interface__` serialization, while `_MultiGeometry` handles most of the cross-cutting behavior.
+
+## Basic Usage
+
+```python
+from pygeoif import Point, LineString, Polygon
+
+point = Point(1.5, 2.0)
+line = LineString([(0, 0), (1, 1), (2, 1)])
+polygon = Polygon([(0, 0), (3, 0), (3, 2), (0, 2), (0, 0)])
+
+print(point.bounds)
+print(line.wkt)
+print(polygon.convex_hull.wkt)
+```
+
+## Advanced Usage
+
+The shared geometry model also handles empty or degenerate inputs in predictable ways.
+
+```python
+from math import nan
+from pygeoif import Point, Polygon
+
+empty_point = Point(1, nan)
+degenerate_polygon = Polygon([(0, 0), (1, 1), (2, 2)])
+
+print(bool(empty_point))
+print(empty_point.wkt)
+print(degenerate_polygon.convex_hull)
+```
+
+In this example the point becomes empty because one coordinate is `NaN`, and the polygon’s convex hull collapses into a `LineString` because all vertices lie on the same line.
+
+<Callout type="warn">`LineString` removes only consecutive duplicate coordinates in `LineString._set_geoms()`. Non-adjacent duplicates are preserved, so you should not assume input lines are globally unique. Also note that a 3D geometry's `convex_hull` works on its XY projection and may drop Z information by design.</Callout>
+
+<Accordions>
+<Accordion title="Why value objects instead of mutable geometries">
+`pygeoif` chooses immutability so geometry instances behave predictably in serialization and equality checks. Once a geometry is created, `.wkt`, `.bounds`, and `.__geo_interface__` cannot silently diverge because some other part of the program edited coordinates in place. That makes `Feature` wrappers safer too, because they can hold a geometry reference without worrying about later mutation. The trade-off is that normalization operations such as `force_2d()` or `orient()` always allocate a new geometry instead of modifying the old one, so you need to plan for explicit replacement in your own code.
+</Accordion>
+<Accordion title="Why multi-geometries do not expose a unified .coords property">
+`_MultiGeometry.coords` deliberately raises `NotImplementedError` in `pygeoif/geometry.py`. A single coordinate sequence would blur the semantic boundary between `MultiPoint`, `MultiPolygon`, and `GeometryCollection`, and it would be ambiguous for nested collections. By forcing callers to iterate `geoms`, the library keeps the container shape explicit and prevents accidental flattening of structured data. The trade-off is a little more code when you want to transform a collection, but the result is much clearer and maps cleanly to GeoJSON.
+</Accordion>
+</Accordions>

--- a/docs/codedocs/guides/geojson-interoperability.md
+++ b/docs/codedocs/guides/geojson-interoperability.md
@@ -1,0 +1,87 @@
+---
+title: "GeoJSON Interoperability"
+description: "Use pygeoif as a bridge between GeoJSON-like mappings, custom __geo_interface__ objects, and immutable Python geometry values."
+---
+
+This guide covers a common integration problem: your application receives geometry from an API or third-party object, needs to normalize it into a predictable Python value object, and then has to send it back out in a GeoJSON-like shape. `pygeoif` solves that with `shape()` and `mapping()`.
+
+<Steps>
+<Step>
+### Accept protocol-compatible input
+
+Start with a plain mapping or any object that exposes `__geo_interface__`.
+
+```python
+incoming = {
+    "type": "Polygon",
+    "coordinates": (
+        ((0, 0), (4, 0), (4, 4), (0, 4), (0, 0)),
+        ((1, 1), (1, 2), (2, 2), (2, 1), (1, 1)),
+    ),
+}
+```
+
+</Step>
+<Step>
+### Normalize it into a pygeoif geometry
+
+`shape()` copies coordinates into a new geometry instance, so downstream code no longer depends on the mutability or quirks of the original object.
+
+```python
+from pygeoif import shape
+
+polygon = shape(incoming)
+
+print(type(polygon).__name__)
+print(polygon.bounds)
+```
+
+</Step>
+<Step>
+### Work with the geometry as a value object
+
+Once normalized, you can use the shared geometry API.
+
+```python
+print(polygon.wkt)
+print(polygon.exterior.is_ccw)
+```
+
+</Step>
+<Step>
+### Export a GeoJSON-like mapping again
+
+Use `mapping()` when you need a plain Python object for serialization or transport.
+
+```python
+from pygeoif import mapping
+
+payload = mapping(polygon)
+print(payload["type"])
+print(payload["coordinates"][0][0])
+```
+
+</Step>
+</Steps>
+
+Complete example:
+
+```python
+from pygeoif import Feature, mapping, orient, shape
+
+incoming = {
+    "type": "Polygon",
+    "coordinates": (
+        ((0, 0), (0, 4), (4, 4), (4, 0), (0, 0)),
+        ((1, 1), (3, 1), (3, 3), (1, 3), (1, 1)),
+    ),
+}
+
+geometry = orient(shape(incoming) ccw=True)
+feature = Feature(geometry properties={"source": "api"}, feature_id="parcel-7")
+
+print(feature.__geo_interface__)
+print(mapping(geometry))
+```
+
+This pattern is especially useful when you consume foreign objects. Any class that implements `__geo_interface__` can be normalized the same way, which keeps the rest of your application independent from the upstream library that originally created the geometry.

--- a/docs/codedocs/guides/hypothesis-testing.md
+++ b/docs/codedocs/guides/hypothesis-testing.md
@@ -1,0 +1,91 @@
+---
+title: "Hypothesis Testing"
+description: "Generate realistic random geometries with pygeoif.hypothesis.strategies for property-based tests."
+---
+
+If your project already uses Hypothesis, `pygeoif` includes a purpose-built strategy module for generating geometry objects and coordinate sequences. This guide shows how to install the optional dependency set and use those strategies to test geometry-heavy code without hand-rolling data generators.
+
+<Steps>
+<Step>
+### Install the optional testing dependencies
+
+```bash
+pip install "pygeoif[hypothesis]"
+```
+
+</Step>
+<Step>
+### Generate geometry objects directly
+
+```python
+from hypothesis import given
+from pygeoif.hypothesis.strategies import points, polygons
+
+@given(points(has_z=False), polygons(max_points=8, has_z=False))
+def test_bounds_are_ordered(point, polygon):
+    minx, miny, maxx, maxy = point.bounds
+    assert minx <= maxx
+    assert miny <= maxy
+    pminx, pminy, pmaxx, pmaxy = polygon.bounds
+    assert pminx <= pmaxx
+    assert pminy <= pmaxy
+```
+
+</Step>
+<Step>
+### Constrain generated coordinates
+
+Use `Srs` and the `srs=` parameter when you need realistic coordinate ranges.
+
+```python
+from hypothesis import given
+from pygeoif.hypothesis.strategies import Srs, point_coords
+
+web_mercator_like = Srs(
+    name="Local",
+    min_xyz=(-1000.0, -1000.0, 0.0),
+    max_xyz=(1000.0, 1000.0, 500.0),
+)
+
+@given(point_coords(srs=web_mercator_like, has_z=True))
+def test_points_stay_in_range(coord):
+    assert -1000.0 <= coord[0] <= 1000.0
+    assert -1000.0 <= coord[1] <= 1000.0
+    assert 0.0 <= coord[2] <= 500.0
+```
+
+</Step>
+<Step>
+### Generate nested collections when needed
+
+```python
+from hypothesis import given
+from pygeoif.hypothesis.strategies import geometry_collections
+
+@given(geometry_collections(max_geoms=4, max_points=6, max_leaves=2))
+def test_collection_serializes(collection):
+    payload = collection.__geo_interface__
+    assert payload["type"] == "GeometryCollection"
+    assert len(payload["geometries"]) <= 4
+```
+
+</Step>
+</Steps>
+
+Complete example:
+
+```python
+from hypothesis import given
+from pygeoif import mapping, shape
+from pygeoif.hypothesis.strategies import multi_polygons
+
+@given(multi_polygons(max_polygons=2, max_points=6, min_interiors=0, max_interiors=1))
+def test_round_trip_via_protocol(geom):
+    payload = mapping(geom)
+    restored = shape(payload)
+    assert restored == geom
+```
+
+The strategy module mirrors the public geometry model closely, so your tests stay aligned with real library behavior. That is especially useful when you want to stress round-tripping, bounds, or shape conversion logic across many geometry shapes and dimensional combinations.
+
+Because the strategies return real `pygeoif` objects, the same test can cover constructor behavior, protocol serialization, and conversion helpers in one place. That makes the optional Hypothesis integration more than a convenience module; it is a practical way to test the exact edge cases the library itself is built around.

--- a/docs/codedocs/guides/wkt-round-tripping.md
+++ b/docs/codedocs/guides/wkt-round-tripping.md
@@ -1,0 +1,83 @@
+---
+title: "WKT Round Tripping"
+description: "Parse WKT into geometry objects, normalize it, and serialize it back out safely."
+---
+
+WKT often shows up at system boundaries: databases, SQL dumps, queue payloads, or CLI tools. This guide shows how to parse WKT with `from_wkt()`, inspect and normalize the result, and emit WKT again through `.wkt`.
+
+<Steps>
+<Step>
+### Parse the incoming WKT
+
+```python
+from pygeoif import from_wkt
+
+geometry = from_wkt(
+    "MULTIPOLYGON (((0 0, 3 0, 3 3, 0 3, 0 0)), ((10 10, 12 10, 12 12, 10 12, 10 10)))"
+)
+
+print(type(geometry).__name__)
+print(len(tuple(geometry.geoms)))
+```
+
+</Step>
+<Step>
+### Inspect the normalized geometry object
+
+```python
+for polygon in geometry.geoms:
+    print(polygon.bounds)
+    print(polygon.convex_hull.wkt)
+```
+
+</Step>
+<Step>
+### Apply dimensional or orientation normalization
+
+```python
+from pygeoif import Polygon, force_3d, orient
+
+single = from_wkt("POLYGON ((0 0, 4 0, 4 3, 0 3, 0 0))")
+single = orient(single ccw=True)
+single_3d = force_3d(single z=100)
+
+print(single.exterior.is_ccw)
+print(single_3d.wkt)
+```
+
+</Step>
+<Step>
+### Handle bad input explicitly
+
+```python
+from pygeoif import from_wkt
+from pygeoif.exceptions import WKTParserError
+
+try:
+    from_wkt("POLYGON ((0 0, broken))")
+except WKTParserError as exc:
+    print(f"Could not parse payload: {exc}")
+```
+
+</Step>
+</Steps>
+
+Complete example:
+
+```python
+from pygeoif import Feature, from_wkt, orient
+
+parcel = orient(
+    from_wkt("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))"),
+    ccw=True,
+)
+
+record = Feature(parcel, {"kind": "parcel"}, feature_id="p-100")
+
+print(parcel.wkt)
+print(record.__geo_interface__)
+```
+
+The important detail is that the round trip happens through a structured geometry model, not by regex-editing WKT strings in place. That means you can validate shape type, inspect bounds, adjust orientation, and only then serialize back to text.
+
+This approach also keeps the rest of your code format-agnostic. Once the WKT is parsed, your application deals with geometry objects and shared helpers instead of raw strings. That makes it much easier to add GeoJSON export, dimensional normalization, or feature wrapping later without rewriting the ingestion path.

--- a/docs/codedocs/index.md
+++ b/docs/codedocs/index.md
@@ -1,0 +1,119 @@
+---
+title: "Getting Started"
+description: "Learn what pygeoif does, why it exists, and how to start working with immutable GeoJSON-like geometries in Python."
+---
+
+`pygeoif` is a pure-Python geometry library that implements the `__geo_interface__` protocol, WKT conversion, and lightweight geometry value objects without a compiled GIS dependency.
+
+## The Problem
+
+- Many Python GIS stacks are excellent but heavy when you only need protocol-compatible geometry objects.
+- Interoperability between GeoJSON-like mappings, custom geometry objects, and WKT strings is easy to get wrong by hand.
+- Dimensionality issues such as mixing 2D and 3D coordinates often surface late and produce inconsistent downstream behavior.
+- Property-based testing of geometry-heavy code usually requires custom strategies before you can even start testing real edge cases.
+
+## The Solution
+
+`pygeoif` gives you immutable geometry classes, GeoJSON-like mappings through `__geo_interface__`, constructors that copy input data instead of aliasing it, and helpers for WKT parsing, dimensional coercion, orientation, and Hypothesis strategy generation.
+
+```python
+from pygeoif import Point, Polygon, Feature, mapping, orient
+
+parcel = Polygon(
+    shell=[(0, 0), (4, 0), (4, 3), (0, 3), (0, 0)],
+    holes=[[(1, 1), (1, 2), (2, 2), (2, 1), (1, 1)]],
+)
+
+feature = Feature(
+    orient(parcel ccw=True),
+    properties={"name": "parcel-a"},
+    feature_id="parcel-1",
+)
+
+print(mapping(feature.geometry))
+print(feature.__geo_interface__["properties"])
+```
+
+## Installation
+
+<Tabs items={["pip", "uv", "poetry", "conda"]}>
+<Tab value="pip">
+
+```bash
+pip install pygeoif
+```
+
+</Tab>
+<Tab value="uv">
+
+```bash
+uv add pygeoif
+```
+
+</Tab>
+<Tab value="poetry">
+
+```bash
+poetry add pygeoif
+```
+
+</Tab>
+<Tab value="conda">
+
+```bash
+conda install -c conda-forge pygeoif
+```
+
+</Tab>
+</Tabs>
+
+`pygeoif` requires Python 3.9 or newer and declares support for CPython, PyPy, and GraalPy in [`pyproject.toml`](https://github.com/cleder/pygeoif/blob/develop/pyproject.toml).
+
+## Quick Start
+
+```python
+from pygeoif import Point, LineString, FeatureCollection, Feature, from_wkt
+
+home = Point(-122.4, 37.78)
+route = LineString([(-122.4, 37.78), (-122.41, 37.79), (-122.42, 37.8)])
+copied = from_wkt("POINT (-122.4 37.78)")
+
+collection = FeatureCollection(
+    [
+        Feature(home, {"kind": "home"}, feature_id="home"),
+        Feature(route, {"kind": "route"}, feature_id="route"),
+    ]
+)
+
+print(home.wkt)
+print(route.bounds)
+print(copied == home)
+print(collection.__geo_interface__["type"])
+```
+
+Expected output:
+
+```text
+POINT (-122.4 37.78)
+(-122.42, 37.78, -122.4, 37.8)
+True
+FeatureCollection
+```
+
+## Key Features
+
+- Immutable geometry classes in [`pygeoif/geometry.py`](https://github.com/cleder/pygeoif/blob/develop/pygeoif/geometry.py).
+- Root-level convenience exports in [`pygeoif/__init__.py`](https://github.com/cleder/pygeoif/blob/develop/pygeoif/__init__.py).
+- GeoJSON-like interoperability via `__geo_interface__`, `shape()`, and `mapping()`.
+- WKT parsing and formatting through `from_wkt()` and `.wkt`.
+- 2D or 3D coercion with `force_2d()` and `force_3d()`.
+- Polygon ring orientation helpers backed by `signed_area()`.
+- Optional Hypothesis strategies in `pygeoif.hypothesis.strategies`.
+
+## Where To Next
+
+<Cards>
+  <Card title="Architecture" href="/docs/architecture">See how geometry classes, factories, and algorithms fit together internally.</Card>
+  <Card title="Core Concepts" href="/docs/geometry-model">Understand immutable geometries, `__geo_interface__`, conversion, and features.</Card>
+  <Card title="API Reference" href="/docs/api-reference/point">Jump into the class and module reference for every public surface.</Card>
+</Cards>


### PR DESCRIPTION
## Auto-generated Code Documentation

AI-analyzed source code to produce structured documentation including:
- Architecture overview with diagrams
- Core concepts and internals
- API reference with parameter tables
- Practical usage guides

**[Browse the documentation →](https://context7.com/cleder/pygeoif/docs)**

---
*Generated by [Context7](https://context7.com) · [View docs](https://context7.com/cleder/pygeoif/docs)*

## Summary by Sourcery

Add an auto-generated documentation section covering pygeoif’s geometry model, factories, exceptions, GeoJSON interoperability, WKT handling, Hypothesis strategies, and feature/collection architecture.

Documentation:
- Document the public APIs for core geometry types, factories, functions, types, exceptions, and feature containers under a new codedocs API reference.
- Add conceptual guides for geometry modeling, GeoJSON interoperability, WKT round-tripping, factory/conversion workflows, Hypothesis-based testing, and feature/collection usage.
- Introduce a getting-started and architecture overview for pygeoif, including installation, key capabilities, and internal module relationships.