### PR TITLE
Compute centroid and signed area relative to a local origin

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,10 @@ Changelog
 1.7.0 (unreleased)
 --------------------
 
+- fix ``centroid`` and ``signed_area`` losing precision for coordinates far from the
+  origin, which made ``LinearRing.centroid`` silently inaccurate or ``None`` for valid
+  rings in projected coordinate systems with a large false easting/northing.
+
 
 
 1.6.0 (2025/10/01)

--- a/pygeoif/functions.py
+++ b/pygeoif/functions.py
@@ -32,6 +32,27 @@ from pygeoif.types import Point2D
 from pygeoif.types import PointType
 
 
+def _relative_coordinates(
+    coords: LineType,
+) -> tuple[list[float], list[float], Point2D]:
+    """
+    Return the x and y coordinates as offsets from the first vertex.
+
+    Shoelace sums are translation invariant in exact arithmetic but not in
+    floating point: the individual terms grow with the square of the coordinate
+    magnitude while their sum only grows with the area, so for a ring that sits
+    far from the origin the significant digits are cancelled away. Accumulating
+    relative to a vertex of the ring keeps the terms the size of the ring
+    itself. The origin is returned so a result can be shifted back.
+    """
+    origin_x, origin_y = coords[0][0], coords[0][1]
+    return (
+        [coord[0] - origin_x for coord in coords],
+        [coord[1] - origin_y for coord in coords],
+        (origin_x, origin_y),
+    )
+
+
 def signed_area(coords: LineType) -> float:
     """
     Return the signed area enclosed by a ring.
@@ -41,37 +62,39 @@ def signed_area(coords: LineType) -> float:
     """
     if len(coords) < 3:  # noqa: PLR2004
         return 0.0
-    xs, ys = map(list, zip(*(coord[:2] for coord in coords), strict=True))
+    xs, ys, _ = _relative_coordinates(coords)
     xs.append(xs[1])  # pragma: no mutate
     ys.append(ys[1])  # pragma: no mutate
-    return cast(
-        "float",
-        sum(xs[i] * (ys[i + 1] - ys[i - 1]) for i in range(1, len(coords))) / 2.0,
-    )
+    return sum(xs[i] * (ys[i + 1] - ys[i - 1]) for i in range(1, len(coords))) / 2.0
 
 
 def centroid(coords: LineType) -> tuple[Point2D, float]:
     """Calculate the coordinates of the centroid and the area of a LineString."""
+    if not coords:
+        return ((math.nan, math.nan), 0.0)
+
+    xs, ys, (origin_x, origin_y) = _relative_coordinates(coords)
     ans: list[float] = [0, 0]
     n = len(coords)
     signed_area = 0.0
 
     # For all vertices
-    for i, coord in enumerate(coords):
-        next_coord = coords[(i + 1) % n]
+    for i in range(n):
+        j = (i + 1) % n
         # Calculate area using shoelace formula
-        area = (coord[0] * next_coord[1]) - (next_coord[0] * coord[1])
+        area = (xs[i] * ys[j]) - (xs[j] * ys[i])
         signed_area += area
 
         # Calculate coordinates of centroid of polygon
-        ans[0] += (coord[0] + next_coord[0]) * area
-        ans[1] += (coord[1] + next_coord[1]) * area
+        ans[0] += (xs[i] + xs[j]) * area
+        ans[1] += (ys[i] + ys[j]) * area
 
     if signed_area == 0 or math.isnan(signed_area):
         return ((math.nan, math.nan), signed_area)
 
-    ans[0] = ans[0] / (3 * signed_area)
-    ans[1] = ans[1] / (3 * signed_area)
+    # Shift the result back out of the local coordinate system.
+    ans[0] = ans[0] / (3 * signed_area) + origin_x
+    ans[1] = ans[1] / (3 * signed_area) + origin_y
 
     return cast("Point2D", tuple(ans)), signed_area / 2.0
 

--- a/pygeoif/functions.py
+++ b/pygeoif/functions.py
@@ -70,7 +70,7 @@ def signed_area(coords: LineType) -> float:
 
 def centroid(coords: LineType) -> tuple[Point2D, float]:
     """Calculate the coordinates of the centroid and the area of a LineString."""
-    if not coords:
+    if len(coords) == 0:
         return ((math.nan, math.nan), 0.0)
 
     xs, ys, (origin_x, origin_y) = _relative_coordinates(coords)

--- a/tests/hypothesis/test_functions.py
+++ b/tests/hypothesis/test_functions.py
@@ -46,6 +46,45 @@ def test_fuzz_centroid(
 
 
 @given(
+    vertices=st.integers(min_value=3, max_value=24),
+    radius=st.floats(min_value=1.0, max_value=1_000.0),
+    center=st.tuples(
+        st.floats(min_value=-100.0, max_value=100.0),
+        st.floats(min_value=-100.0, max_value=100.0),
+    ),
+    offset=st.sampled_from([0.0, 1e3, 1e5, 1e7, 1e9, 1e10]),
+)
+def test_centroid_of_a_regular_polygon_is_its_center(
+    vertices: int,
+    radius: float,
+    center: tuple[float, float],
+    offset: float,
+) -> None:
+    """
+    The centroid of a regular polygon is its center by symmetry.
+
+    A closed form expectation that does not share any arithmetic with the
+    implementation, so unlike a shape-only assertion it detects a centroid
+    that has silently lost its significant digits.
+    """
+    expected_x, expected_y = center[0] + offset, center[1] + offset
+    coords = [
+        (
+            expected_x + radius * math.cos(2 * math.pi * step / vertices),
+            expected_y + radius * math.sin(2 * math.pi * step / vertices),
+        )
+        for step in range(vertices)
+    ]
+    coords.append(coords[0])
+
+    computed, _ = pygeoif.functions.centroid(coords=coords)
+
+    tolerance = 32 * math.ulp(max(abs(value) for point in coords for value in point))
+    assert abs(computed[0] - expected_x) <= tolerance
+    assert abs(computed[1] - expected_y) <= tolerance
+
+
+@given(
     coords=st.one_of(
         st.floats(),
         st.lists(st.tuples(st.floats(), st.floats())),

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -3,6 +3,7 @@
 import itertools
 import math
 import random
+from fractions import Fraction
 
 import pytest
 
@@ -105,6 +106,104 @@ def test_signed_area_circle_ish() -> None:
             assert 3.0 * r**2 < area1 < 3.2 * r**2
         if steps > 30:
             assert 3.1 * r**2 < area1 < 3.2 * r**2
+
+
+def exact_centroid_and_area(coords):
+    """
+    Centroid and area of a ring in exact rational arithmetic.
+
+    Independent oracle for the floating point implementation: the vertices are
+    the same but no rounding takes place anywhere in the computation.
+    """
+    points = [(Fraction(coord[0]), Fraction(coord[1])) for coord in coords]
+    double_area = Fraction(0)
+    acc_x = Fraction(0)
+    acc_y = Fraction(0)
+    for (x0, y0), (x1, y1) in zip(points, points[1:] + points[:1], strict=True):
+        cross = x0 * y1 - x1 * y0
+        double_area += cross
+        acc_x += (x0 + x1) * cross
+        acc_y += (y0 + y1) * cross
+    return acc_x / (3 * double_area), acc_y / (3 * double_area), double_area / 2
+
+
+def offset_ring(ring, offset):
+    return [(x + offset, y + offset) for x, y in ring]
+
+
+def ulp_tolerance(ring, ulps=32):
+    return ulps * math.ulp(max(abs(value) for point in ring for value in point))
+
+
+SQUARE = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)]
+TRIANGLE = [(0.0, 0.0), (10.0, 0.0), (0.0, 10.0), (0.0, 0.0)]
+L_SHAPE = [
+    (0.0, 0.0),
+    (10.0, 0.0),
+    (10.0, 5.0),
+    (5.0, 5.0),
+    (5.0, 10.0),
+    (0.0, 10.0),
+    (0.0, 0.0),
+]
+# a 10 m long, 1 mm thick wall
+WALL = [(0.0, 0.0), (10.0, 0.0), (10.0, 0.001), (0.0, 0.001), (0.0, 0.0)]
+RINGS = (SQUARE, TRIANGLE, L_SHAPE, WALL)
+# 1e12 is the last decade where the 1 mm thick wall is still representable
+OFFSETS = [10.0**exponent for exponent in range(13)]
+
+
+def test_centroid_far_from_the_origin() -> None:
+    for ring in RINGS:
+        for offset in OFFSETS:
+            moved = offset_ring(ring, offset)
+
+            center, area = centroid(moved)
+            expected_x, expected_y, expected_area = exact_centroid_and_area(moved)
+
+            tolerance = ulp_tolerance(moved)
+            assert abs(center[0] - float(expected_x)) <= tolerance
+            assert abs(center[1] - float(expected_y)) <= tolerance
+            assert math.isclose(area, float(expected_area))
+
+
+def test_centroid_is_translation_invariant() -> None:
+    for ring in RINGS:
+        base, _ = centroid(ring)
+        for offset in OFFSETS:
+            moved = offset_ring(ring, offset)
+
+            center, _ = centroid(moved)
+
+            tolerance = ulp_tolerance(moved)
+            assert abs(center[0] - (base[0] + offset)) <= tolerance
+            assert abs(center[1] - (base[1] + offset)) <= tolerance
+
+
+def test_centroid_area_agrees_with_signed_area_far_from_the_origin() -> None:
+    for ring in RINGS:
+        for offset in OFFSETS:
+            moved = offset_ring(ring, offset)
+
+            assert math.isclose(centroid(moved)[1], signed_area(moved))
+
+
+def test_signed_area_far_from_the_origin() -> None:
+    ring = circle_ish(0, 0, 10, 24)
+    for offset in OFFSETS:
+        moved = offset_ring(ring, offset)
+
+        *_, expected_area = exact_centroid_and_area(moved)
+
+        assert math.isclose(signed_area(moved), float(expected_area), rel_tol=1e-15)
+
+
+def test_centroid_empty() -> None:
+    center, area = centroid([])
+
+    assert math.isnan(center[0])
+    assert math.isnan(center[1])
+    assert area == 0
 
 
 def test_signed_area_crescent_ish() -> None:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -210,13 +210,13 @@ def test_centroid_empty() -> None:
 def test_centroid_empty_sequence_with_ambiguous_truthiness() -> None:
     class EmptySequence(Sequence[tuple[float, float]]):
         def __getitem__(self, index: int) -> tuple[float, float]:
-            raise IndexError(index)
+            raise IndexError(index)  # pragma: no cover
 
         def __len__(self) -> int:
             return 0
 
         def __bool__(self) -> bool:
-            raise AssertionError
+            raise AssertionError  # pragma: no cover
 
     center, area = centroid(EmptySequence())
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -3,6 +3,7 @@
 import itertools
 import math
 import random
+from collections.abc import Sequence
 from fractions import Fraction
 
 import pytest
@@ -200,6 +201,24 @@ def test_signed_area_far_from_the_origin() -> None:
 
 def test_centroid_empty() -> None:
     center, area = centroid([])
+
+    assert math.isnan(center[0])
+    assert math.isnan(center[1])
+    assert area == 0
+
+
+def test_centroid_empty_sequence_with_ambiguous_truthiness() -> None:
+    class EmptySequence(Sequence[tuple[float, float]]):
+        def __getitem__(self, index: int) -> tuple[float, float]:
+            raise IndexError(index)
+
+        def __len__(self) -> int:
+            return 0
+
+        def __bool__(self) -> bool:
+            raise AssertionError
+
+    center, area = centroid(EmptySequence())
 
     assert math.isnan(center[0])
     assert math.isnan(center[1])

--- a/tests/test_linear_ring.py
+++ b/tests/test_linear_ring.py
@@ -191,6 +191,37 @@ def test_centroid_valid() -> None:
     assert line.centroid == geometry.Point(2, 1)
 
 
+def test_centroid_valid_far_from_the_origin() -> None:
+    # a valid ring must not lose its centroid to a large false easting/northing
+    for exponent in range(13):
+        offset = 10.0**exponent
+        line = geometry.LinearRing(
+            [
+                (offset, offset),
+                (offset + 4, offset),
+                (offset + 4, offset + 2),
+                (offset, offset + 2),
+            ],
+        )
+
+        assert line.centroid == geometry.Point(offset + 2, offset + 1)
+
+
+def test_centroid_thin_ring_far_from_the_origin() -> None:
+    # a 10 m long, 1 mm thick wall in a metre based projected coordinate system
+    offset = 10_000.0
+    line = geometry.LinearRing(
+        [
+            (offset, offset),
+            (offset + 10, offset),
+            (offset + 10, offset + 0.001),
+            (offset, offset + 0.001),
+        ],
+    )
+
+    assert line.centroid == geometry.Point(offset + 5, offset + 0.0005)
+
+
 def test_empty() -> None:
     ring = geometry.LinearRing([])
 


### PR DESCRIPTION
Both shoelace sums in `functions.py` accumulate in absolute coordinates. The per-edge terms grow with the square of the coordinate magnitude while their sum only grows with the area, so for a ring that sits far from the origin the significant digits cancel away. `centroid()` is hit hardest because it multiplies before it subtracts:

```python
area = (coord[0] * next_coord[1]) - (next_coord[0] * coord[1])
```

A 10x10 square moved to `x = y = 1e10`:

```python
>>> from pygeoif.geometry import LinearRing
>>> o = 1e10
>>> ring = LinearRing([(o, o), (o + 10, o), (o + 10, o + 10), (o, o + 10)])
>>> ring.centroid
None                                    # expected POINT (10000000005.0 10000000005.0)
>>> from pygeoif.functions import centroid
>>> centroid(ring.coords)[0]
(6646321618.666667, 6646321618.666667)  # 3.4e9 off
```

Two different symptoms, both from the same sum. Either the coordinates are wrong and nothing says so, or `centroid()`'s internal area drifts far enough from `signed_area()` that the `math.isclose` check in `LinearRing.centroid` rejects a perfectly valid ring. The check is not a safety net for the coordinates: at an offset of `1e8` the two areas still agree exactly at `100.0` while the centroid is already off by 0.04.

The threshold depends on how thin the ring is, not only on the offset. A 10 m long, 1 mm thick ring — a wall in a metre-based projected system — loses its centroid at an offset of `1e4`:

```python
>>> o = 10_000.0
>>> LinearRing([(o, o), (o + 10, o), (o + 10, o + 0.001), (o, o + 0.001)]).centroid
None                                    # expected POINT (10005.0 10000.0005)
```

Fix: subtract the first vertex from every coordinate before accumulating, so the terms stay the size of the ring, and shift the centroid back at the end. Areas are translation invariant so they need no correction. shapely, on GEOS, returns the exact value for every case above.

### Extent of the problem

I checked the whole of `functions.py` rather than just the reported case, against an exact `fractions.Fraction` evaluation over the same vertices, on a grid of {square, triangle, L-shape, 1 mm sliver, 24-gon} x {shift x, shift y, shift both} x offsets `1e0..1e15`:

- `centroid()` — wrong in every shape/direction combination. Included.
- `signed_area()` — same accumulation, but it differences the y coordinates before multiplying, so it degrades much more slowly: relative error `9e-5` on the 24-gon at an offset of `1e13`, `3e-4` at `1e14`. Small, but it is the same bug and the same one-line fix, so it is in. I also confirmed by exact evaluation that its formula is mathematically identical to the standard one, i.e. only the rounding was at fault. After the fix it is exact on the whole grid.
- `_orientation()` / `convex_hull()` — already difference before multiplying and the magnitudes never cancel. Zero sign errors across the entire grid, so left alone. The only degeneracies are at `1e14`+ where the 1 mm sliver is no longer representable at all, which no arithmetic can fix.
- `move_coordinate(s)`, `Bounds` — no products, unaffected.

Two claims I could not support and want to flag rather than have you find them: this is **not** a problem for ordinary Web-Mercator or UTM data. A 20x12 m footprint at EPSG:3857 `(1489200, 6894000)` comes out exact. What does break is large false eastings, millimetre-based CAD/IFC coordinates, and thin rings, which is what the tests use.

### Tests

- `test_centroid_far_from_the_origin`, `test_centroid_is_translation_invariant`, `test_signed_area_far_from_the_origin` — 4 rings x 13 offsets against exact rational arithmetic and against the untranslated result, to within 32 ulp of the coordinate magnitude.
- `test_centroid_valid_far_from_the_origin`, `test_centroid_thin_ring_far_from_the_origin` — the two `LinearRing.centroid` symptoms above.
- `test_centroid_of_a_regular_polygon_is_its_center` — a hypothesis test with a closed-form expectation. `test_fuzz_centroid` is the only property test that reaches `centroid()` and its assertion is shape-only (`area is nan` iff `center is nan`), so it cannot see this class of bug at all; I left it alone because its unbounded `st.floats()` draws leave nothing numeric to assert, and added the new one next to it instead. It survives `--hypothesis-profile=exhaustive` (10 000 examples), with a worst observed error of 4.5 ulp; before the fix 77% of that domain exceeds the 32 ulp bound and 4% comes back `nan`.

I mutated the fix in six ways (no translation at all, no shift back, wrong sign, shifting back twice, translating only x, leaving `signed_area` alone) — each reddens. Taking the last vertex as the origin instead of the first stays green, so the tests pin the property and not my particular choice.

`pytest tests --hypothesis-profile=ci` 437 pass, coverage stays at 100%, `mypy`, `ruff format --check`, `complexipy`, `radon`, `lizard` clean. `ruff check` reports the same 28 pre-existing `CPY001` findings as `develop` does.

This was prepared with the assistance of an AI coding agent working under my direction; I have reviewed the change and the reasoning above and I am accountable for it.

## Summary by Sourcery

Improve numerical robustness of centroid and signed area computations for rings, especially far from the origin, and add comprehensive tests for these behaviors.

Bug Fixes:
- Fix centroid computation so it remains accurate for rings located far from the coordinate origin and for thin rings with large offsets.
- Ensure signed_area remains accurate under large coordinate translations by basing calculations on coordinates relative to a local origin.
- Define centroid behavior for empty coordinate sequences by returning NaN coordinates and zero area.

Enhancements:
- Introduce a helper to compute ring coordinates relative to a local origin and reuse it in area and centroid calculations to reduce floating-point cancellation.
- Add a property-based test asserting that the centroid of a regular polygon matches its geometric center across a range of sizes and offsets.

Tests:
- Add exact rational-arithmetic oracle and offset-based tests to validate centroid and signed_area accuracy and translation invariance over multiple ring shapes and offset magnitudes.
- Add LinearRing tests to ensure valid rings retain correct centroids even when far from the origin or very thin with large offsets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved centroid and signed-area accuracy for shapes located far from the coordinate origin.
  - Fixed inaccurate or missing `LinearRing` centroid results for projected coordinates with large offsets.
  - Added consistent handling for empty geometry input.

- **Tests**
  - Added coverage for large offsets, thin rings, translated geometries, and regular polygons.
  - Added precise arithmetic and tolerance-based validation.

- **Documentation**
  - Documented the upcoming precision improvements in the 1.7.0 changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->